### PR TITLE
[P1-03] Implement om_client.py — OM API wrapper with retry, timeout & typed errors

### DIFF
--- a/src/pulse/exceptions.py
+++ b/src/pulse/exceptions.py
@@ -1,0 +1,41 @@
+"""Custom exceptions for OpenMetadata Pulse."""
+
+from __future__ import annotations
+
+
+class PulseError(Exception):
+    """Base exception for all Pulse errors."""
+
+
+class OMClientError(PulseError):
+    """Raised when an OpenMetadata API call fails.
+
+    Attributes:
+        status_code: HTTP status code (if applicable).
+        detail: Human-readable error detail.
+        url: The URL that was called.
+    """
+
+    def __init__(
+        self,
+        detail: str,
+        *,
+        status_code: int | None = None,
+        url: str = "",
+    ) -> None:
+        self.status_code = status_code
+        self.detail = detail
+        self.url = url
+        super().__init__(f"OMClientError({status_code}): {detail} [{url}]")
+
+
+class OMConnectionError(OMClientError):
+    """Raised when the OM server is unreachable."""
+
+
+class OMAuthError(OMClientError):
+    """Raised on 401/403 from the OM server."""
+
+
+class OMNotFoundError(OMClientError):
+    """Raised on 404 from the OM server."""

--- a/src/pulse/om_client.py
+++ b/src/pulse/om_client.py
@@ -1,52 +1,253 @@
-"""OpenMetadata MCP client wrapper using data-ai-sdk.
+"""OpenMetadata API client with retry, timeout, and structured error handling.
 
-Provides typed helpers around search_metadata, get_entity_details,
-and get_entity_lineage.
+Provides typed async helpers around the OM REST API:
+- ``search_metadata``  — full-text entity search
+- ``get_entity_details``  — fetch single entity by FQN
+- ``get_entity_lineage``  — fetch lineage graph for an entity
+- ``check_health``  — verify OM server connectivity
+
+All functions use *httpx* with configurable timeout and automatic
+retry on transient (5xx / timeout) errors.
 """
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import httpx
 import structlog
 
 from pulse.config import settings
+from pulse.exceptions import (
+    OMAuthError,
+    OMClientError,
+    OMConnectionError,
+    OMNotFoundError,
+)
 
 logger = structlog.get_logger(__name__)
 
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+_TIMEOUT = httpx.Timeout(connect=5.0, read=15.0, write=10.0, pool=5.0)
+_MAX_RETRIES = 3
+_RETRY_BACKOFF_BASE = 0.5  # seconds
+_RETRYABLE_STATUS_CODES = {502, 503, 504}
 
-async def search_metadata(query: str, limit: int = 10) -> list[dict[str, Any]]:
-    """Search OM for entities matching *query*."""
-    url = f"{settings.om_server_url}/api/v1/search/query"
-    params = {"q": query, "size": limit}
-    headers = {"Authorization": f"Bearer {settings.om_api_token}"}
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(url, params=params, headers=headers)
-        resp.raise_for_status()
-        data = resp.json()
-    hits = data.get("hits", {}).get("hits", [])
-    logger.info("search_metadata", query=query, hits=len(hits))
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _base_url() -> str:
+    return settings.om_server_url.rstrip("/")
+
+
+def _auth_headers() -> dict[str, str]:
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if settings.om_api_token:
+        headers["Authorization"] = f"Bearer {settings.om_api_token}"
+    return headers
+
+
+def _raise_for_status(response: httpx.Response, url: str) -> None:
+    """Map HTTP error codes to typed exceptions."""
+    code = response.status_code
+    if 200 <= code < 300:
+        return
+
+    detail = response.text[:500]
+
+    if code in (401, 403):
+        raise OMAuthError(detail, status_code=code, url=url)
+    if code == 404:
+        raise OMNotFoundError(detail, status_code=code, url=url)
+    raise OMClientError(detail, status_code=code, url=url)
+
+
+async def _request_with_retry(
+    method: str,
+    url: str,
+    *,
+    params: dict[str, Any] | None = None,
+    json_body: dict[str, Any] | None = None,
+) -> httpx.Response:
+    """Execute an HTTP request with exponential-backoff retry on transient errors."""
+    last_exc: Exception | None = None
+
+    for attempt in range(1, _MAX_RETRIES + 1):
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+                response = await client.request(
+                    method,
+                    url,
+                    headers=_auth_headers(),
+                    params=params,
+                    json=json_body,
+                )
+
+            if response.status_code not in _RETRYABLE_STATUS_CODES:
+                _raise_for_status(response, url)
+                return response
+
+            last_exc = OMClientError(
+                response.text[:500],
+                status_code=response.status_code,
+                url=url,
+            )
+            logger.warning(
+                "om_request_retryable",
+                attempt=attempt,
+                status=response.status_code,
+                url=url,
+            )
+
+        except httpx.ConnectError as exc:
+            last_exc = OMConnectionError(
+                f"Cannot connect to OpenMetadata at {url}: {exc}",
+                url=url,
+            )
+            logger.warning("om_connect_error", attempt=attempt, url=url, error=str(exc))
+
+        except httpx.TimeoutException as exc:
+            last_exc = OMConnectionError(
+                f"Timeout connecting to OpenMetadata at {url}: {exc}",
+                url=url,
+            )
+            logger.warning("om_timeout", attempt=attempt, url=url, error=str(exc))
+
+        if attempt < _MAX_RETRIES:
+            wait = _RETRY_BACKOFF_BASE * (2 ** (attempt - 1))
+            await asyncio.sleep(wait)
+
+    # All retries exhausted
+    assert last_exc is not None
+    raise last_exc
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def check_health() -> dict[str, Any]:
+    """Verify connectivity to the OM server.
+
+    Returns the OM version payload on success.
+    Raises ``OMConnectionError`` if the server is unreachable.
+    """
+    url = f"{_base_url()}/api/v1/system/version"
+    logger.info("om_health_check", url=url)
+    response = await _request_with_retry("GET", url)
+    data: dict[str, Any] = response.json()
+    logger.info("om_health_ok", version=data.get("version", "unknown"))
+    return data
+
+
+async def search_metadata(
+    query: str,
+    *,
+    limit: int = 10,
+    index: str = "table_search_index",
+) -> list[dict[str, Any]]:
+    """Search OM for entities matching *query*.
+
+    Args:
+        query: Free-text search query.
+        limit: Maximum number of results.
+        index: OM search index to query.
+
+    Returns:
+        List of hit source dicts from the OM search response.
+    """
+    url = f"{_base_url()}/api/v1/search/query"
+    params = {"q": query, "size": limit, "index": index}
+
+    logger.info("om_search", query=query, limit=limit, index=index)
+    response = await _request_with_retry("GET", url, params=params)
+    data = response.json()
+
+    hits_raw = data.get("hits", {}).get("hits", [])
+    hits = [h.get("_source", h) for h in hits_raw]
+    total = data.get("hits", {}).get("total", {}).get("value", len(hits))
+
+    logger.info("om_search_results", query=query, total=total, returned=len(hits))
     return hits
 
 
-async def get_entity_details(entity_type: str, fqn: str) -> dict[str, Any]:
-    """Fetch full details for a single OM entity."""
-    url = f"{settings.om_server_url}/api/v1/{entity_type}/name/{fqn}"
-    headers = {"Authorization": f"Bearer {settings.om_api_token}"}
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(url, headers=headers)
-        resp.raise_for_status()
-    logger.info("get_entity_details", entity_type=entity_type, fqn=fqn)
-    return resp.json()
+async def get_entity_details(
+    entity_type: str,
+    fqn: str,
+    *,
+    fields: str = "owner,tags,followers,tier",
+) -> dict[str, Any]:
+    """Fetch full details for a single OM entity by FQN.
+
+    Args:
+        entity_type: OM entity type (e.g. ``table``, ``topic``, ``dashboard``).
+        fqn: Fully-qualified name of the entity.
+        fields: Comma-separated list of fields to include.
+
+    Returns:
+        Entity detail dict.
+
+    Raises:
+        OMNotFoundError: If the entity does not exist.
+    """
+    url = f"{_base_url()}/api/v1/{entity_type}/name/{fqn}"
+    params = {"fields": fields}
+
+    logger.info("om_get_entity", entity_type=entity_type, fqn=fqn)
+    response = await _request_with_retry("GET", url, params=params)
+    entity: dict[str, Any] = response.json()
+
+    logger.info(
+        "om_entity_fetched",
+        entity_type=entity_type,
+        fqn=fqn,
+        entity_id=entity.get("id", "unknown"),
+    )
+    return entity
 
 
-async def get_entity_lineage(entity_type: str, entity_id: str) -> dict[str, Any]:
-    """Fetch lineage graph for an entity."""
-    url = f"{settings.om_server_url}/api/v1/lineage/{entity_type}/{entity_id}"
-    headers = {"Authorization": f"Bearer {settings.om_api_token}"}
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(url, headers=headers)
-        resp.raise_for_status()
-    logger.info("get_entity_lineage", entity_type=entity_type, entity_id=entity_id)
-    return resp.json()
+async def get_entity_lineage(
+    entity_type: str,
+    entity_id: str,
+    *,
+    upstream_depth: int = 3,
+    downstream_depth: int = 3,
+) -> dict[str, Any]:
+    """Fetch lineage graph for an entity.
+
+    Args:
+        entity_type: OM entity type.
+        entity_id: UUID of the entity.
+        upstream_depth: How many levels upstream to traverse.
+        downstream_depth: How many levels downstream to traverse.
+
+    Returns:
+        Lineage graph dict with ``nodes`` and ``edges``.
+    """
+    url = f"{_base_url()}/api/v1/lineage/{entity_type}/{entity_id}"
+    params = {
+        "upstreamDepth": upstream_depth,
+        "downstreamDepth": downstream_depth,
+    }
+
+    logger.info("om_get_lineage", entity_type=entity_type, entity_id=entity_id)
+    response = await _request_with_retry("GET", url, params=params)
+    lineage: dict[str, Any] = response.json()
+
+    node_count = len(lineage.get("nodes", []))
+    edge_count = len(lineage.get("downstreamEdges", [])) + len(
+        lineage.get("upstreamEdges", [])
+    )
+    logger.info(
+        "om_lineage_fetched",
+        entity_id=entity_id,
+        nodes=node_count,
+        edges=edge_count,
+    )
+    return lineage

--- a/tests/test_om_client.py
+++ b/tests/test_om_client.py
@@ -1,0 +1,215 @@
+"""Unit tests for the OM client wrapper.
+
+All external HTTP calls are mocked via respx.
+"""
+
+import pytest
+import respx
+from httpx import Response
+
+from pulse.exceptions import (
+    OMAuthError,
+    OMClientError,
+    OMConnectionError,
+    OMNotFoundError,
+)
+from pulse.om_client import (
+    check_health,
+    get_entity_details,
+    get_entity_lineage,
+    search_metadata,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+OM_BASE = "http://localhost:8585"
+
+
+@pytest.fixture(autouse=True)
+def _patch_settings(monkeypatch):
+    """Point the client at a local test URL."""
+    monkeypatch.setenv("OM_SERVER_URL", OM_BASE)
+    monkeypatch.setenv("OM_API_TOKEN", "test-token")
+    # Force settings reload
+    from pulse.config import Settings
+    import pulse.om_client as mod
+    import pulse.config
+    pulse.config.settings = Settings()
+    mod.settings = pulse.config.settings
+
+
+# ---------------------------------------------------------------------------
+# check_health
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_check_health_success():
+    respx.get(f"{OM_BASE}/api/v1/system/version").mock(
+        return_value=Response(200, json={"version": "1.4.0"})
+    )
+    result = await check_health()
+    assert result["version"] == "1.4.0"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_check_health_unreachable():
+    import httpx as _httpx
+    respx.get(f"{OM_BASE}/api/v1/system/version").mock(
+        side_effect=_httpx.ConnectError("refused")
+    )
+    with pytest.raises(OMConnectionError):
+        await check_health()
+
+
+# ---------------------------------------------------------------------------
+# search_metadata
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_search_metadata_returns_hits():
+    payload = {
+        "hits": {
+            "total": {"value": 2},
+            "hits": [
+                {"_source": {"id": "1", "name": "orders"}},
+                {"_source": {"id": "2", "name": "users"}},
+            ],
+        }
+    }
+    respx.get(f"{OM_BASE}/api/v1/search/query").mock(
+        return_value=Response(200, json=payload)
+    )
+    hits = await search_metadata("table", limit=5)
+    assert len(hits) == 2
+    assert hits[0]["name"] == "orders"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_search_metadata_empty():
+    payload = {"hits": {"total": {"value": 0}, "hits": []}}
+    respx.get(f"{OM_BASE}/api/v1/search/query").mock(
+        return_value=Response(200, json=payload)
+    )
+    hits = await search_metadata("nonexistent")
+    assert hits == []
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_search_metadata_auth_error():
+    respx.get(f"{OM_BASE}/api/v1/search/query").mock(
+        return_value=Response(401, text="Unauthorized")
+    )
+    with pytest.raises(OMAuthError):
+        await search_metadata("table")
+
+
+# ---------------------------------------------------------------------------
+# get_entity_details
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_entity_details_success():
+    entity = {"id": "abc-123", "name": "orders", "fullyQualifiedName": "sample.public.orders"}
+    respx.get(f"{OM_BASE}/api/v1/table/name/sample.public.orders").mock(
+        return_value=Response(200, json=entity)
+    )
+    result = await get_entity_details("table", "sample.public.orders")
+    assert result["id"] == "abc-123"
+    assert result["fullyQualifiedName"] == "sample.public.orders"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_entity_details_not_found():
+    respx.get(f"{OM_BASE}/api/v1/table/name/does.not.exist").mock(
+        return_value=Response(404, text="Not Found")
+    )
+    with pytest.raises(OMNotFoundError):
+        await get_entity_details("table", "does.not.exist")
+
+
+# ---------------------------------------------------------------------------
+# get_entity_lineage
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_get_entity_lineage_success():
+    lineage = {
+        "entity": {"id": "abc-123"},
+        "nodes": [{"id": "n1"}, {"id": "n2"}],
+        "downstreamEdges": [{"fromEntity": "abc-123", "toEntity": "n1"}],
+        "upstreamEdges": [{"fromEntity": "n2", "toEntity": "abc-123"}],
+    }
+    respx.get(f"{OM_BASE}/api/v1/lineage/table/abc-123").mock(
+        return_value=Response(200, json=lineage)
+    )
+    result = await get_entity_lineage("table", "abc-123")
+    assert len(result["nodes"]) == 2
+    assert len(result["downstreamEdges"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Retry behaviour
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_retry_on_503_then_success(monkeypatch):
+    """Client should retry on 503 and succeed on the next attempt."""
+    import pulse.om_client as mod
+    monkeypatch.setattr(mod, "_RETRY_BACKOFF_BASE", 0.01)  # speed up test
+
+    route = respx.get(f"{OM_BASE}/api/v1/system/version")
+    route.side_effect = [
+        Response(503, text="Service Unavailable"),
+        Response(200, json={"version": "1.4.0"}),
+    ]
+    result = await check_health()
+    assert result["version"] == "1.4.0"
+    assert route.call_count == 2
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_retry_exhausted_raises(monkeypatch):
+    """After all retries exhausted, the last error should propagate."""
+    import pulse.om_client as mod
+    monkeypatch.setattr(mod, "_RETRY_BACKOFF_BASE", 0.01)
+    monkeypatch.setattr(mod, "_MAX_RETRIES", 2)
+
+    respx.get(f"{OM_BASE}/api/v1/system/version").mock(
+        return_value=Response(503, text="down")
+    )
+    with pytest.raises(OMClientError):
+        await check_health()
+
+
+# ---------------------------------------------------------------------------
+# Auth header injection
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_auth_header_sent():
+    """Verify the Bearer token is included in requests."""
+    route = respx.get(f"{OM_BASE}/api/v1/system/version").mock(
+        return_value=Response(200, json={"version": "1.4.0"})
+    )
+    await check_health()
+    request = route.calls[0].request
+    assert request.headers["Authorization"] == "Bearer test-token"


### PR DESCRIPTION
## Summary

Implements production-ready async OM API client, resolving all acceptance criteria from Issue #1.

Closes #1

## What Changed

### New: `src/pulse/exceptions.py`
Custom exception hierarchy for typed error handling:
- `PulseError` — base exception
- `OMClientError(detail, status_code, url)` — generic API errors
- `OMConnectionError` — server unreachable / timeout
- `OMAuthError` — 401/403 responses
- `OMNotFoundError` — 404 responses

### Rewritten: `src/pulse/om_client.py`
Replaced the bare stub (3 raw `httpx` functions, no error handling) with a production-ready client:

| Function | Endpoint | Description |
|----------|----------|-------------|
| `check_health()` | `/api/v1/system/version` | Verify OM connectivity, return version |
| `search_metadata(query, limit, index)` | `/api/v1/search/query` | Full-text search, returns parsed `_source` hits |
| `get_entity_details(entity_type, fqn, fields)` | `/api/v1/{type}/name/{fqn}` | Single entity by FQN |
| `get_entity_lineage(entity_type, entity_id, depths)` | `/api/v1/lineage/{type}/{id}` | Lineage graph with upstream/downstream |

**Infrastructure:**
- Exponential-backoff retry (3 attempts) on 502/503/504 + connection errors + timeouts
- `httpx.Timeout(connect=5s, read=15s, write=10s, pool=5s)`
- `structlog` logging on every request/response with context fields
- `_raise_for_status()` maps HTTP codes → typed exceptions
- Bearer token injection from `settings.om_api_token`

### New: `tests/test_om_client.py`
11 unit tests using `respx` mocks:
- ✅ `check_health` success + unreachable
- ✅ `search_metadata` with hits, empty results, auth error (401)
- ✅ `get_entity_details` success + 404 not found
- ✅ `get_entity_lineage` success
- ✅ Retry on 503 → success on second attempt
- ✅ Retry exhausted → raises `OMClientError`
- ✅ Auth header injection verification

## Acceptance Criteria Checklist

- [x] `search_metadata(query, limit)` returns typed list of search hits
- [x] `get_entity_details(entity_type, fqn)` returns full entity dict
- [x] `get_entity_lineage(entity_type, entity_id)` returns lineage graph
- [x] All functions async with `httpx.AsyncClient`
- [x] Auth token passed via `Authorization: Bearer` header
- [x] Structured logging via `structlog` (query, hit count)
- [x] Graceful error handling: `httpx.HTTPStatusError` caught and re-raised with context

## How to Validate

```bash
pytest tests/test_om_client.py -v
```