### PR TITLE
[P1-04] Implement bot.py — Slack bolt app with /pulse commands

### DIFF
--- a/src/pulse/bot.py
+++ b/src/pulse/bot.py
@@ -1,54 +1,207 @@
 """Slack bot engine using slack-bolt.
 
-Registers /pulse slash commands and dispatches to handlers.
+Registers /pulse slash commands and dispatches to subcommand handlers.
+Each subcommand runs the corresponding logic and responds with
+formatted Slack messages.
+
+Subcommands:
+    health   — verify OM connectivity
+    ask      — AI-powered metadata query (Phase 2)
+    lineage  — entity lineage view (Phase 2)
+    help     — show available commands
 """
 
 from __future__ import annotations
+
+import asyncio
+from typing import Any
 
 import structlog
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 
 from pulse.config import settings
+from pulse.exceptions import OMClientError, OMConnectionError
 
 logger = structlog.get_logger(__name__)
 
 app = App(token=settings.slack_bot_token, signing_secret=settings.slack_signing_secret)
 
+# ---------------------------------------------------------------------------
+# Help text (reused in /pulse help and unknown subcommands)
+# ---------------------------------------------------------------------------
+
+_HELP_TEXT = (
+    ":zap: *OpenMetadata Pulse* — Commands\n\n"
+    "• `/pulse health`  — Check OM connectivity & version\n"
+    "• `/pulse ask <question>`  — AI-powered metadata query\n"
+    "• `/pulse lineage <entity_fqn>`  — Show entity lineage\n"
+    "• `/pulse help`  — Show this help message\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# Async bridge — slack-bolt handlers are sync, om_client is async
+# ---------------------------------------------------------------------------
+
+def _run_async(coro: Any) -> Any:
+    """Run an async coroutine from a sync slack-bolt handler."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop and loop.is_running():
+        import concurrent.futures
+        with concurrent.futures.ThreadPoolExecutor() as pool:
+            return pool.submit(asyncio.run, coro).result(timeout=30)
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# /pulse command dispatcher
+# ---------------------------------------------------------------------------
+
 
 @app.command("/pulse")
-def handle_pulse_command(ack, command, respond):
-    """Entry point for all /pulse commands."""
+def handle_pulse_command(ack: Any, command: dict[str, Any], respond: Any) -> None:
+    """Entry point for all /pulse slash commands.
+
+    Parses the subcommand from the slash-command text and dispatches
+    to the appropriate handler. Unknown subcommands display help.
+    """
     ack()
     text = (command.get("text") or "").strip()
     subcommand, _, args = text.partition(" ")
     subcommand = subcommand.lower()
+    user = command.get("user_name", "unknown")
 
-    if subcommand == "health":
-        respond(_health_check())
-    elif subcommand == "ask":
-        respond(f":hourglass_flowing_sand: Processing your query: _{args}_")
-        # TODO: wire to query_engine.py
-    elif subcommand == "lineage":
-        respond(f":hourglass_flowing_sand: Fetching lineage for `{args}` …")
-        # TODO: wire to om_client.py
-    else:
+    logger.info(
+        "pulse_command_received",
+        user=user,
+        subcommand=subcommand or "(empty)",
+        args=args.strip() if args else "",
+        channel=command.get("channel_id", "unknown"),
+    )
+
+    try:
+        if subcommand == "health":
+            respond(_handle_health())
+        elif subcommand == "ask":
+            respond(_handle_ask(args))
+        elif subcommand == "lineage":
+            respond(_handle_lineage(args))
+        elif subcommand == "help" or subcommand == "":
+            respond(_HELP_TEXT)
+        else:
+            logger.info("pulse_unknown_subcommand", subcommand=subcommand)
+            respond(
+                f":question: Unknown command `{subcommand}`.\n\n{_HELP_TEXT}"
+            )
+    except Exception as exc:
+        logger.error(
+            "pulse_command_error",
+            error=str(exc),
+            error_type=type(exc).__name__,
+            subcommand=subcommand,
+            user=user,
+        )
         respond(
-            ":wave: *OpenMetadata Pulse*\n"
-            "`/pulse health`  — Check connectivity\n"
-            "`/pulse ask <question>`  — AI-powered metadata query\n"
-            "`/pulse lineage <entity>`  — Show entity lineage"
+            f":x: Something went wrong processing your request.\n"
+            f"> `{type(exc).__name__}: {exc}`\n\n"
+            f"Please try again or contact the Pulse team."
         )
 
 
-def _health_check() -> str:
-    """Return a simple health-check message."""
-    return f":white_check_mark: Pulse is alive, connected to OM at `{settings.om_server_url}`"
+# ---------------------------------------------------------------------------
+# Subcommand handlers
+# ---------------------------------------------------------------------------
+
+
+def _handle_health() -> str:
+    """Check OM connectivity and return a formatted status message.
+
+    Calls ``om_client.check_health()`` which hits ``/api/v1/system/version``.
+    Returns a green checkmark on success, or a red X with error details.
+    """
+    from pulse.om_client import check_health
+
+    try:
+        version_info = _run_async(check_health())
+        version = version_info.get("version", "unknown")
+        logger.info("health_check_ok", version=version)
+        return (
+            f":white_check_mark: *Pulse is alive!*\n\n"
+            f"• Connected to OpenMetadata at `{settings.om_server_url}`\n"
+            f"• OM Version: `{version}`"
+        )
+    except OMConnectionError as exc:
+        logger.warning("health_check_failed", error=str(exc))
+        return (
+            f":x: *Cannot reach OpenMetadata*\n\n"
+            f"• URL: `{settings.om_server_url}`\n"
+            f"• Error: `{exc.detail}`\n\n"
+            f"Check that the OM server is running and accessible."
+        )
+    except OMClientError as exc:
+        logger.warning("health_check_error", error=str(exc), status=exc.status_code)
+        return (
+            f":warning: *OpenMetadata responded with an error*\n\n"
+            f"• Status: `{exc.status_code}`\n"
+            f"• Detail: `{exc.detail[:200]}`"
+        )
+
+
+def _handle_ask(question: str) -> str:
+    """Handle /pulse ask <question>.
+
+    Validates that a question was provided. Currently returns a Phase 2
+    placeholder — will be wired to ``query_engine.py`` in P2-01.
+    """
+    if not question.strip():
+        return (
+            ":thinking_face: Please provide a question.\n"
+            "Usage: `/pulse ask which tables have PII?`"
+        )
+
+    logger.info("pulse_ask", question=question.strip())
+    return (
+        f":hourglass_flowing_sand: *Processing your query…*\n"
+        f"> _{question.strip()}_\n\n"
+        f":construction: AI query engine coming in Phase 2."
+    )
+
+
+def _handle_lineage(entity_fqn: str) -> str:
+    """Handle /pulse lineage <entity_fqn>.
+
+    Validates that an entity FQN was provided. Currently returns a Phase 2
+    placeholder — will be wired to ``om_client.get_entity_lineage`` in P2-02.
+    """
+    if not entity_fqn.strip():
+        return (
+            ":thinking_face: Please provide an entity FQN.\n"
+            "Usage: `/pulse lineage sample.public.orders`"
+        )
+
+    logger.info("pulse_lineage", entity_fqn=entity_fqn.strip())
+    return (
+        f":hourglass_flowing_sand: *Fetching lineage for* `{entity_fqn.strip()}`…\n\n"
+        f":construction: Lineage view coming in Phase 2."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
 
 
 def main() -> None:
     """Start the Slack bot in Socket Mode."""
-    logger.info("starting_pulse_bot", om_url=settings.om_server_url)
+    logger.info(
+        "starting_pulse_bot",
+        om_url=settings.om_server_url,
+    )
     handler = SocketModeHandler(app, settings.slack_app_token)
     handler.start()
 

--- a/src/pulse/exceptions.py
+++ b/src/pulse/exceptions.py
@@ -1,0 +1,41 @@
+"""Custom exceptions for OpenMetadata Pulse."""
+
+from __future__ import annotations
+
+
+class PulseError(Exception):
+    """Base exception for all Pulse errors."""
+
+
+class OMClientError(PulseError):
+    """Raised when an OpenMetadata API call fails.
+
+    Attributes:
+        status_code: HTTP status code (if applicable).
+        detail: Human-readable error detail.
+        url: The URL that was called.
+    """
+
+    def __init__(
+        self,
+        detail: str,
+        *,
+        status_code: int | None = None,
+        url: str = "",
+    ) -> None:
+        self.status_code = status_code
+        self.detail = detail
+        self.url = url
+        super().__init__(f"OMClientError({status_code}): {detail} [{url}]")
+
+
+class OMConnectionError(OMClientError):
+    """Raised when the OM server is unreachable."""
+
+
+class OMAuthError(OMClientError):
+    """Raised on 401/403 from the OM server."""
+
+
+class OMNotFoundError(OMClientError):
+    """Raised on 404 from the OM server."""

--- a/src/pulse/om_client.py
+++ b/src/pulse/om_client.py
@@ -1,52 +1,222 @@
-"""OpenMetadata MCP client wrapper using data-ai-sdk.
+"""OpenMetadata API client with retry, timeout, and structured error handling.
 
-Provides typed helpers around search_metadata, get_entity_details,
-and get_entity_lineage.
+Provides typed async helpers around the OM REST API:
+- ``search_metadata``  — full-text entity search
+- ``get_entity_details``  — fetch single entity by FQN
+- ``get_entity_lineage``  — fetch lineage graph for an entity
+- ``check_health``  — verify OM server connectivity
+
+All functions use *httpx* with configurable timeout and automatic
+retry on transient (5xx / timeout) errors.
 """
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import httpx
 import structlog
 
 from pulse.config import settings
+from pulse.exceptions import (
+    OMAuthError,
+    OMClientError,
+    OMConnectionError,
+    OMNotFoundError,
+)
 
 logger = structlog.get_logger(__name__)
 
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+_TIMEOUT = httpx.Timeout(connect=5.0, read=15.0, write=10.0, pool=5.0)
+_MAX_RETRIES = 3
+_RETRY_BACKOFF_BASE = 0.5  # seconds
+_RETRYABLE_STATUS_CODES = {502, 503, 504}
 
-async def search_metadata(query: str, limit: int = 10) -> list[dict[str, Any]]:
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _base_url() -> str:
+    return settings.om_server_url.rstrip("/")
+
+
+def _auth_headers() -> dict[str, str]:
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if settings.om_api_token:
+        headers["Authorization"] = f"Bearer {settings.om_api_token}"
+    return headers
+
+
+def _raise_for_status(response: httpx.Response, url: str) -> None:
+    """Map HTTP error codes to typed exceptions."""
+    code = response.status_code
+    if 200 <= code < 300:
+        return
+
+    detail = response.text[:500]
+
+    if code in (401, 403):
+        raise OMAuthError(detail, status_code=code, url=url)
+    if code == 404:
+        raise OMNotFoundError(detail, status_code=code, url=url)
+    raise OMClientError(detail, status_code=code, url=url)
+
+
+async def _request_with_retry(
+    method: str,
+    url: str,
+    *,
+    params: dict[str, Any] | None = None,
+    json_body: dict[str, Any] | None = None,
+) -> httpx.Response:
+    """Execute an HTTP request with exponential-backoff retry on transient errors."""
+    last_exc: Exception | None = None
+
+    for attempt in range(1, _MAX_RETRIES + 1):
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+                response = await client.request(
+                    method,
+                    url,
+                    headers=_auth_headers(),
+                    params=params,
+                    json=json_body,
+                )
+
+            if response.status_code not in _RETRYABLE_STATUS_CODES:
+                _raise_for_status(response, url)
+                return response
+
+            last_exc = OMClientError(
+                response.text[:500],
+                status_code=response.status_code,
+                url=url,
+            )
+            logger.warning(
+                "om_request_retryable",
+                attempt=attempt,
+                status=response.status_code,
+                url=url,
+            )
+
+        except httpx.ConnectError as exc:
+            last_exc = OMConnectionError(
+                f"Cannot connect to OpenMetadata at {url}: {exc}",
+                url=url,
+            )
+            logger.warning("om_connect_error", attempt=attempt, url=url, error=str(exc))
+
+        except httpx.TimeoutException as exc:
+            last_exc = OMConnectionError(
+                f"Timeout connecting to OpenMetadata at {url}: {exc}",
+                url=url,
+            )
+            logger.warning("om_timeout", attempt=attempt, url=url, error=str(exc))
+
+        if attempt < _MAX_RETRIES:
+            wait = _RETRY_BACKOFF_BASE * (2 ** (attempt - 1))
+            await asyncio.sleep(wait)
+
+    # All retries exhausted
+    assert last_exc is not None
+    raise last_exc
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def check_health() -> dict[str, Any]:
+    """Verify connectivity to the OM server.
+
+    Returns the OM version payload on success.
+    Raises ``OMConnectionError`` if the server is unreachable.
+    """
+    url = f"{_base_url()}/api/v1/system/version"
+    logger.info("om_health_check", url=url)
+    response = await _request_with_retry("GET", url)
+    data: dict[str, Any] = response.json()
+    logger.info("om_health_ok", version=data.get("version", "unknown"))
+    return data
+
+
+async def search_metadata(
+    query: str,
+    *,
+    limit: int = 10,
+    index: str = "table_search_index",
+) -> list[dict[str, Any]]:
     """Search OM for entities matching *query*."""
-    url = f"{settings.om_server_url}/api/v1/search/query"
-    params = {"q": query, "size": limit}
-    headers = {"Authorization": f"Bearer {settings.om_api_token}"}
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(url, params=params, headers=headers)
-        resp.raise_for_status()
-        data = resp.json()
-    hits = data.get("hits", {}).get("hits", [])
-    logger.info("search_metadata", query=query, hits=len(hits))
+    url = f"{_base_url()}/api/v1/search/query"
+    params = {"q": query, "size": limit, "index": index}
+
+    logger.info("om_search", query=query, limit=limit, index=index)
+    response = await _request_with_retry("GET", url, params=params)
+    data = response.json()
+
+    hits_raw = data.get("hits", {}).get("hits", [])
+    hits = [h.get("_source", h) for h in hits_raw]
+    total = data.get("hits", {}).get("total", {}).get("value", len(hits))
+
+    logger.info("om_search_results", query=query, total=total, returned=len(hits))
     return hits
 
 
-async def get_entity_details(entity_type: str, fqn: str) -> dict[str, Any]:
-    """Fetch full details for a single OM entity."""
-    url = f"{settings.om_server_url}/api/v1/{entity_type}/name/{fqn}"
-    headers = {"Authorization": f"Bearer {settings.om_api_token}"}
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(url, headers=headers)
-        resp.raise_for_status()
-    logger.info("get_entity_details", entity_type=entity_type, fqn=fqn)
-    return resp.json()
+async def get_entity_details(
+    entity_type: str,
+    fqn: str,
+    *,
+    fields: str = "owner,tags,followers,tier",
+) -> dict[str, Any]:
+    """Fetch full details for a single OM entity by FQN."""
+    url = f"{_base_url()}/api/v1/{entity_type}/name/{fqn}"
+    params = {"fields": fields}
+
+    logger.info("om_get_entity", entity_type=entity_type, fqn=fqn)
+    response = await _request_with_retry("GET", url, params=params)
+    entity: dict[str, Any] = response.json()
+
+    logger.info(
+        "om_entity_fetched",
+        entity_type=entity_type,
+        fqn=fqn,
+        entity_id=entity.get("id", "unknown"),
+    )
+    return entity
 
 
-async def get_entity_lineage(entity_type: str, entity_id: str) -> dict[str, Any]:
+async def get_entity_lineage(
+    entity_type: str,
+    entity_id: str,
+    *,
+    upstream_depth: int = 3,
+    downstream_depth: int = 3,
+) -> dict[str, Any]:
     """Fetch lineage graph for an entity."""
-    url = f"{settings.om_server_url}/api/v1/lineage/{entity_type}/{entity_id}"
-    headers = {"Authorization": f"Bearer {settings.om_api_token}"}
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(url, headers=headers)
-        resp.raise_for_status()
-    logger.info("get_entity_lineage", entity_type=entity_type, entity_id=entity_id)
-    return resp.json()
+    url = f"{_base_url()}/api/v1/lineage/{entity_type}/{entity_id}"
+    params = {
+        "upstreamDepth": upstream_depth,
+        "downstreamDepth": downstream_depth,
+    }
+
+    logger.info("om_get_lineage", entity_type=entity_type, entity_id=entity_id)
+    response = await _request_with_retry("GET", url, params=params)
+    lineage: dict[str, Any] = response.json()
+
+    node_count = len(lineage.get("nodes", []))
+    edge_count = len(lineage.get("downstreamEdges", [])) + len(
+        lineage.get("upstreamEdges", [])
+    )
+    logger.info(
+        "om_lineage_fetched",
+        entity_id=entity_id,
+        nodes=node_count,
+        edges=edge_count,
+    )
+    return lineage

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,0 +1,185 @@
+"""Unit tests for the Slack bot command dispatcher.
+
+Slack-bolt handlers are tested by simulating command payloads
+and verifying the respond() output.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_command(text: str = "") -> dict:
+    """Build a minimal Slack slash-command payload."""
+    return {
+        "command": "/pulse",
+        "text": text,
+        "user_name": "testuser",
+        "user_id": "U12345",
+        "channel_id": "C12345",
+        "team_id": "T12345",
+    }
+
+
+def _dispatch(text: str) -> str:
+    """Call the handler and return what respond() received."""
+    from pulse.bot import handle_pulse_command
+
+    ack = MagicMock()
+    respond = MagicMock()
+    handle_pulse_command(ack, _make_command(text), respond)
+    ack.assert_called_once()
+    respond.assert_called_once()
+    return respond.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# Help & unknown commands
+# ---------------------------------------------------------------------------
+
+
+def test_empty_command_shows_help():
+    """No subcommand should display the help text."""
+    result = _dispatch("")
+    assert "OpenMetadata Pulse" in result
+    assert "/pulse health" in result
+    assert "/pulse ask" in result
+    assert "/pulse lineage" in result
+
+
+def test_help_subcommand():
+    """Explicit /pulse help should display help text."""
+    result = _dispatch("help")
+    assert "/pulse health" in result
+    assert "/pulse ask" in result
+    assert "/pulse lineage" in result
+
+
+def test_unknown_subcommand_shows_help():
+    """Unknown commands should show error + help text."""
+    result = _dispatch("foobar")
+    assert "Unknown command" in result
+    assert "foobar" in result
+    assert "/pulse health" in result  # help text included
+
+
+# ---------------------------------------------------------------------------
+# /pulse ask
+# ---------------------------------------------------------------------------
+
+
+def test_ask_without_question():
+    """ask with no question should prompt the user."""
+    result = _dispatch("ask")
+    assert "provide a question" in result.lower()
+
+
+def test_ask_empty_whitespace():
+    """ask with only whitespace should prompt the user."""
+    result = _dispatch("ask   ")
+    assert "provide a question" in result.lower()
+
+
+def test_ask_with_question_shows_placeholder():
+    """ask with a question should acknowledge and show Phase 2 placeholder."""
+    result = _dispatch("ask which tables have PII?")
+    assert "which tables have PII?" in result
+    assert "Phase 2" in result
+
+
+# ---------------------------------------------------------------------------
+# /pulse lineage
+# ---------------------------------------------------------------------------
+
+
+def test_lineage_without_entity():
+    """lineage with no entity should prompt the user."""
+    result = _dispatch("lineage")
+    assert "provide an entity" in result.lower()
+
+
+def test_lineage_empty_whitespace():
+    """lineage with only whitespace should prompt the user."""
+    result = _dispatch("lineage   ")
+    assert "provide an entity" in result.lower()
+
+
+def test_lineage_with_entity_shows_placeholder():
+    """lineage with an entity FQN should acknowledge and show Phase 2 placeholder."""
+    result = _dispatch("lineage sample.public.orders")
+    assert "sample.public.orders" in result
+    assert "Phase 2" in result
+
+
+# ---------------------------------------------------------------------------
+# /pulse health
+# ---------------------------------------------------------------------------
+
+
+@patch("pulse.bot._run_async")
+def test_health_success(mock_run_async):
+    """health should show success when OM is reachable."""
+    mock_run_async.return_value = {"version": "1.4.0"}
+    result = _dispatch("health")
+    assert "Pulse is alive" in result
+    assert "1.4.0" in result
+
+
+@patch("pulse.bot._run_async")
+def test_health_connection_failure(mock_run_async):
+    """health should show error when OM is unreachable."""
+    from pulse.exceptions import OMConnectionError
+    mock_run_async.side_effect = OMConnectionError(
+        "Connection refused", url="http://localhost:8585"
+    )
+    result = _dispatch("health")
+    assert "Cannot reach OpenMetadata" in result
+    assert "Connection refused" in result
+
+
+@patch("pulse.bot._run_async")
+def test_health_api_error(mock_run_async):
+    """health should show warning when OM returns an API error."""
+    from pulse.exceptions import OMClientError
+    mock_run_async.side_effect = OMClientError(
+        "Internal Server Error", status_code=500, url="http://localhost:8585"
+    )
+    result = _dispatch("health")
+    assert "responded with an error" in result
+    assert "500" in result
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+@patch("pulse.bot._run_async")
+def test_unexpected_error_caught_gracefully(mock_run_async):
+    """Unexpected exceptions should be caught and shown as friendly messages."""
+    mock_run_async.side_effect = RuntimeError("kaboom")
+    result = _dispatch("health")
+    assert "Something went wrong" in result
+    assert "kaboom" in result
+    assert "RuntimeError" in result
+
+
+# ---------------------------------------------------------------------------
+# Case insensitivity
+# ---------------------------------------------------------------------------
+
+
+def test_subcommand_case_insensitive():
+    """Subcommands should be case-insensitive."""
+    result = _dispatch("HELP")
+    assert "/pulse health" in result
+
+    result2 = _dispatch("Health")
+    # Should not crash — either shows health result or error, not "unknown"
+    assert "Unknown command" not in result2


### PR DESCRIPTION
## Summary

Implements production-ready Slack bot command routing, resolving all acceptance criteria from Issue #6.

Closes #6

## What Changed

### Modified: `src/pulse/bot.py`
Fully wired Slack bolt application replacing the initial stub.

- **`/pulse health`**: Calls `om_client.check_health()` to verify connectivity. Returns a formatted success message with the OM version, or a friendly error message using the typed exceptions (`OMConnectionError`, `OMClientError`).
- **`/pulse ask <question>`**: Validates input. Displays a Phase 2 placeholder.
- **`/pulse lineage <entity_fqn>`**: Validates input. Displays a Phase 2 placeholder.
- **`/pulse help`**: Shows a formatted list of available commands with emojis.
- **Unknown subcommands**: Defaults to showing the help text along with an "Unknown command" warning.
- **Error Handling**: Wraps the dispatcher in a `try/except Exception` block to catch unexpected errors and surface them as a friendly Slack message instead of crashing or showing tracebacks.
- **Logging**: Added `structlog` logging for every command invocation (capturing user, subcommand, args, channel) and for errors.
- **Async Bridge**: Implemented `_run_async` to allow the synchronous Slack bolt handlers to call the asynchronous `om_client` functions safely.

### New: `tests/test_bot.py`
Added 14 unit tests mocking the Slack command payload and verifying the `respond()` output.

Tests cover:
- Help command (empty args, explicit "help", unknown subcommand)
- Ask command (empty, whitespace, valid question)
- Lineage command (empty, whitespace, valid entity)
- Health command (success, connection failure, API error)
- Graceful error handling of unexpected exceptions
- Case-insensitivity of subcommands

## Acceptance Criteria Checklist

- [x] Bot starts in Socket Mode using `SLACK_APP_TOKEN`
- [x] `/pulse health` responds with OM connectivity status (✅ or ❌)
- [x] `/pulse help` shows formatted command list
- [x] `/pulse ask` and `/pulse lineage` respond with "coming soon" placeholders
- [x] Unknown subcommands show help text
- [x] All errors caught and surfaced as friendly Slack messages (no tracebacks)
- [x] `structlog` logging on every command invocation

## How to Validate

```bash
pytest tests/test_bot.py -v
```