### PR TITLE
[P1-04] Implement bot.py — Slack bolt app with /pulse commands

### DIFF
--- a/src/pulse/bot.py
+++ b/src/pulse/bot.py
@@ -1,51 +1,157 @@
 """Slack bot engine using slack-bolt.
 
 Registers /pulse slash commands and dispatches to handlers.
+Subcommands:
+  - health  — verify OM connectivity
+  - ask     — AI-powered metadata query (Phase 2)
+  - lineage — entity lineage lookup (Phase 2)
+  - help    — show available commands
 """
 
 from __future__ import annotations
+
+import traceback
+from typing import Any
 
 import structlog
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 
 from pulse.config import settings
+from pulse.om_client import search_metadata
 
 logger = structlog.get_logger(__name__)
 
 app = App(token=settings.slack_bot_token, signing_secret=settings.slack_signing_secret)
 
+# ---------------------------------------------------------------------------
+# Help text (reused by /pulse help and unknown subcommands)
+# ---------------------------------------------------------------------------
+HELP_TEXT = (
+    ":zap: *OpenMetadata Pulse — Commands*\n\n"
+    "`/pulse health`  — Check OM connectivity status\n"
+    "`/pulse ask <question>`  — AI-powered metadata query _(coming soon)_\n"
+    "`/pulse lineage <entity>`  — Show entity lineage _(coming soon)_\n"
+    "`/pulse help`  — Show this help message"
+)
 
+
+# ---------------------------------------------------------------------------
+# Slash-command handler
+# ---------------------------------------------------------------------------
 @app.command("/pulse")
-def handle_pulse_command(ack, command, respond):
+def handle_pulse_command(ack, command, respond):  # noqa: ANN001
     """Entry point for all /pulse commands."""
     ack()
-    text = (command.get("text") or "").strip()
+
+    text: str = (command.get("text") or "").strip()
     subcommand, _, args = text.partition(" ")
     subcommand = subcommand.lower()
+    user_id: str = command.get("user_id", "unknown")
 
-    if subcommand == "health":
-        respond(_health_check())
-    elif subcommand == "ask":
-        respond(f":hourglass_flowing_sand: Processing your query: _{args}_")
-        # TODO: wire to query_engine.py
-    elif subcommand == "lineage":
-        respond(f":hourglass_flowing_sand: Fetching lineage for `{args}` …")
-        # TODO: wire to om_client.py
-    else:
+    logger.info(
+        "pulse_command_received",
+        user=user_id,
+        subcommand=subcommand or "(empty)",
+        args=args,
+    )
+
+    try:
+        if subcommand == "health":
+            respond(_health_check())
+        elif subcommand == "ask":
+            _handle_ask(respond, args)
+        elif subcommand == "lineage":
+            _handle_lineage(respond, args)
+        elif subcommand == "help":
+            respond(HELP_TEXT)
+        else:
+            # Unknown or empty subcommand → show help
+            respond(HELP_TEXT)
+    except Exception:
+        error_msg = traceback.format_exc()
+        logger.error("pulse_command_error", user=user_id, subcommand=subcommand, error=error_msg)
         respond(
-            ":wave: *OpenMetadata Pulse*\n"
-            "`/pulse health`  — Check connectivity\n"
-            "`/pulse ask <question>`  — AI-powered metadata query\n"
-            "`/pulse lineage <entity>`  — Show entity lineage"
+            ":x: *Oops!* Something went wrong processing your command.\n"
+            "Please try again or contact the Pulse team."
         )
 
 
+# ---------------------------------------------------------------------------
+# Subcommand handlers
+# ---------------------------------------------------------------------------
 def _health_check() -> str:
-    """Return a simple health-check message."""
-    return f":white_check_mark: Pulse is alive, connected to OM at `{settings.om_server_url}`"
+    """Verify OM connectivity by attempting a search API call."""
+    import asyncio
+
+    logger.info("health_check_start", om_url=settings.om_server_url)
+
+    try:
+        # Run the async search_metadata in a sync context
+        loop: asyncio.AbstractEventLoop
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None  # type: ignore[assignment]
+
+        if loop and loop.is_running():
+            # If there's already a running loop, create a new thread
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor() as pool:
+                results: list[dict[str, Any]] = pool.submit(
+                    asyncio.run, search_metadata("*", limit=1)
+                ).result(timeout=10)
+        else:
+            results = asyncio.run(search_metadata("*", limit=1))
+
+        logger.info("health_check_success", om_url=settings.om_server_url, hits=len(results))
+        return (
+            f":white_check_mark: *Pulse is healthy!*\n"
+            f"• Connected to OpenMetadata at `{settings.om_server_url}`\n"
+            f"• Search API responding — {len(results)} result(s) returned"
+        )
+    except Exception as exc:
+        logger.error("health_check_failed", om_url=settings.om_server_url, error=str(exc))
+        return (
+            f":x: *OM connectivity issue*\n"
+            f"• Cannot reach OpenMetadata at `{settings.om_server_url}`\n"
+            f"• Error: `{exc!s}`\n"
+            f"• Check that OM is running and `OM_SERVER_URL` / `OM_API_TOKEN` are correct."
+        )
 
 
+def _handle_ask(respond, args: str) -> None:  # noqa: ANN001
+    """Placeholder for AI-powered metadata query (Phase 2)."""
+    if not args.strip():
+        respond(":warning: Please provide a question. Usage: `/pulse ask <question>`")
+        return
+    logger.info("ask_placeholder", question=args)
+    respond(
+        f":hourglass_flowing_sand: *AI Query — Coming Soon!*\n"
+        f"Your question: _{args}_\n\n"
+        f"This feature will use GPT-4o-mini + OpenMetadata MCP tools to "
+        f"answer natural-language metadata queries."
+    )
+
+
+def _handle_lineage(respond, args: str) -> None:  # noqa: ANN001
+    """Placeholder for entity lineage lookup (Phase 2)."""
+    if not args.strip():
+        respond(":warning: Please provide an entity name. Usage: `/pulse lineage <entity>`")
+        return
+    logger.info("lineage_placeholder", entity=args)
+    respond(
+        f":hourglass_flowing_sand: *Lineage — Coming Soon!*\n"
+        f"Entity: `{args}`\n\n"
+        f"This feature will show the upstream/downstream lineage graph "
+        f"for the specified entity."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
 def main() -> None:
     """Start the Slack bot in Socket Mode."""
     logger.info("starting_pulse_bot", om_url=settings.om_server_url)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,0 +1,146 @@
+"""Tests for pulse.bot — Slack slash command handlers."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pulse.bot import HELP_TEXT, _handle_ask, _handle_lineage, _health_check, handle_pulse_command
+
+
+class TestHandlePulseCommand:
+    """Test the main /pulse command dispatcher."""
+
+    def _make_command(self, text: str = "") -> dict:
+        return {"text": text, "user_id": "U12345", "channel_id": "C12345"}
+
+    def test_health_subcommand(self):
+        ack = MagicMock()
+        respond = MagicMock()
+        command = self._make_command("health")
+
+        with patch("pulse.bot._health_check", return_value=":white_check_mark: OK"):
+            handle_pulse_command(ack=ack, command=command, respond=respond)
+
+        ack.assert_called_once()
+        respond.assert_called_once_with(":white_check_mark: OK")
+
+    def test_help_subcommand(self):
+        ack = MagicMock()
+        respond = MagicMock()
+        command = self._make_command("help")
+
+        handle_pulse_command(ack=ack, command=command, respond=respond)
+
+        ack.assert_called_once()
+        respond.assert_called_once_with(HELP_TEXT)
+
+    def test_unknown_subcommand_shows_help(self):
+        ack = MagicMock()
+        respond = MagicMock()
+        command = self._make_command("foobar")
+
+        handle_pulse_command(ack=ack, command=command, respond=respond)
+
+        ack.assert_called_once()
+        respond.assert_called_once_with(HELP_TEXT)
+
+    def test_empty_text_shows_help(self):
+        ack = MagicMock()
+        respond = MagicMock()
+        command = self._make_command("")
+
+        handle_pulse_command(ack=ack, command=command, respond=respond)
+
+        ack.assert_called_once()
+        respond.assert_called_once_with(HELP_TEXT)
+
+    def test_ask_subcommand(self):
+        ack = MagicMock()
+        respond = MagicMock()
+        command = self._make_command("ask which tables have no owner?")
+
+        handle_pulse_command(ack=ack, command=command, respond=respond)
+
+        ack.assert_called_once()
+        call_args = respond.call_args[0][0]
+        assert "Coming Soon" in call_args
+        assert "which tables have no owner?" in call_args
+
+    def test_lineage_subcommand(self):
+        ack = MagicMock()
+        respond = MagicMock()
+        command = self._make_command("lineage users_table")
+
+        handle_pulse_command(ack=ack, command=command, respond=respond)
+
+        ack.assert_called_once()
+        call_args = respond.call_args[0][0]
+        assert "Coming Soon" in call_args
+        assert "users_table" in call_args
+
+    def test_error_handling(self):
+        ack = MagicMock()
+        respond = MagicMock()
+        command = self._make_command("health")
+
+        with patch("pulse.bot._health_check", side_effect=RuntimeError("boom")):
+            handle_pulse_command(ack=ack, command=command, respond=respond)
+
+        ack.assert_called_once()
+        call_args = respond.call_args[0][0]
+        assert "Oops" in call_args
+
+
+class TestHealthCheck:
+    """Test the health check function."""
+
+    def test_healthy_response(self):
+        with patch("pulse.bot.search_metadata", new_callable=AsyncMock) as mock_search:
+            mock_search.return_value = [{"_source": {"name": "test"}}]
+            result = _health_check()
+
+        assert "healthy" in result.lower() or "check_mark" in result
+        assert "1 result" in result
+
+    def test_unhealthy_response(self):
+        with patch("pulse.bot.search_metadata", new_callable=AsyncMock) as mock_search:
+            mock_search.side_effect = ConnectionError("Connection refused")
+            result = _health_check()
+
+        assert "connectivity issue" in result.lower() or ":x:" in result
+
+
+class TestAskHandler:
+    """Test the ask placeholder handler."""
+
+    def test_ask_with_question(self):
+        respond = MagicMock()
+        _handle_ask(respond, "which tables have PII?")
+        call_args = respond.call_args[0][0]
+        assert "Coming Soon" in call_args
+        assert "which tables have PII?" in call_args
+
+    def test_ask_without_question(self):
+        respond = MagicMock()
+        _handle_ask(respond, "")
+        call_args = respond.call_args[0][0]
+        assert "warning" in call_args.lower() or "provide" in call_args.lower()
+
+
+class TestLineageHandler:
+    """Test the lineage placeholder handler."""
+
+    def test_lineage_with_entity(self):
+        respond = MagicMock()
+        _handle_lineage(respond, "users_table")
+        call_args = respond.call_args[0][0]
+        assert "Coming Soon" in call_args
+        assert "users_table" in call_args
+
+    def test_lineage_without_entity(self):
+        respond = MagicMock()
+        _handle_lineage(respond, "")
+        call_args = respond.call_args[0][0]
+        assert "warning" in call_args.lower() or "provide" in call_args.lower()


### PR DESCRIPTION
## Summary
Enhances `src/pulse/bot.py` with a fully wired Slack bolt application.

## Changes
- `/pulse health` — Calls `om_client.search_metadata()` to verify OM connectivity (pass/fail)
- `/pulse help` — Formatted help text with all available commands
- `/pulse ask <question>` — Coming soon placeholder with validation
- `/pulse lineage <entity>` — Coming soon placeholder with validation
- Unknown/empty subcommands show help text
- All exceptions caught and surfaced as friendly Slack messages
- structlog logging on every command invocation with user context

## Tests
Added `tests/test_bot.py` with comprehensive coverage for all subcommands, error handling, and edge cases.

Closes #6