### PR TITLE
[P1-11] Docker: complete docker-compose with MySQL + ES for OM

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,140 @@
-# OpenMetadata Pulse — development stack
+# OpenMetadata Pulse — Development Stack
+# =============================================================================
+# This docker-compose file sets up the full development environment:
+#   - OpenMetadata server (UI + API at :8585)
+#   - MySQL 8 (backing store for OM metadata)
+#   - Elasticsearch 7.16.3 (search index for OM)
+#   - Pulse API server (webhook receiver + dashboard API at :8000)
+#   - Pulse Slack bot (Socket Mode)
+#
+# Usage:
+#   docker-compose up -d                    # Start all services
+#   docker-compose up openmetadata -d       # Start only OM + dependencies
+#   docker-compose logs -f openmetadata     # Tail OM logs
+#
+# Verify OM is running:
+#   curl http://localhost:8585/api/v1/system/version
+# =============================================================================
+
 version: "3.9"
 
 services:
-  # OpenMetadata (use official image)
+  # ---------------------------------------------------------------------------
+  # MySQL 8 — OpenMetadata metadata store
+  # ---------------------------------------------------------------------------
+  mysql:
+    image: mysql:8
+    container_name: pulse-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_USER: openmetadata_user
+      MYSQL_PASSWORD: openmetadata_password
+      MYSQL_DATABASE: openmetadata_db
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-ppassword"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # Elasticsearch 7.16.3 — OpenMetadata search index
+  # ---------------------------------------------------------------------------
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.3
+    container_name: pulse-elasticsearch
+    environment:
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    volumes:
+      - es_data:/usr/share/elasticsearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -q '\"status\":\"green\"\\|\"status\":\"yellow\"'"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # OpenMetadata Server — UI at :8585, API at :8585/api/v1
+  # ---------------------------------------------------------------------------
   openmetadata:
     image: openmetadata/server:latest
+    container_name: pulse-openmetadata
     ports:
       - "8585:8585"
     environment:
-      - OPENMETADATA_CLUSTER_NAME=openmetadata
+      OPENMETADATA_CLUSTER_NAME: openmetadata
+      # Database connection
+      DB_DRIVER_CLASS: com.mysql.cj.jdbc.Driver
+      DB_SCHEME: mysql
+      DB_USE_SSL: "false"
+      DB_USER: openmetadata_user
+      DB_USER_PASSWORD: openmetadata_password
+      DB_HOST: mysql
+      DB_PORT: "3306"
+      SERVER_HOST_API_URL: http://openmetadata:8585/api
+      # Elasticsearch connection
+      ELASTICSEARCH_HOST: elasticsearch
+      ELASTICSEARCH_PORT: "9200"
+      ELASTICSEARCH_SCHEME: http
+      # Airflow (disabled — not needed for dev)
+      PIPELINE_SERVICE_CLIENT_ENABLED: "false"
+      # Auth (JWT for API token generation)
+      AUTHENTICATION_PROVIDER: basic
+      AUTHORIZER_ADMIN_PRINCIPALS: "[admin]"
+      AUTHORIZER_PRINCIPAL_DOMAIN: "open-metadata.org"
+    depends_on:
+      mysql:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8585/api/v1/system/version || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 120s
     restart: unless-stopped
 
+  # ---------------------------------------------------------------------------
   # Pulse API server (webhook receiver + dashboard API)
+  # ---------------------------------------------------------------------------
   pulse-api:
     build: .
+    container_name: pulse-api
     ports:
       - "8000:8000"
     env_file: .env
     depends_on:
-      - openmetadata
+      openmetadata:
+        condition: service_healthy
     command: python -m pulse.server
+    restart: unless-stopped
 
-  # Pulse Slack bot
+  # ---------------------------------------------------------------------------
+  # Pulse Slack bot (Socket Mode)
+  # ---------------------------------------------------------------------------
   pulse-bot:
     build: .
+    container_name: pulse-bot
     env_file: .env
     depends_on:
-      - openmetadata
+      openmetadata:
+        condition: service_healthy
     command: python -m pulse.bot
+    restart: unless-stopped
+
+volumes:
+  mysql_data:
+    driver: local
+  es_data:
+    driver: local


### PR DESCRIPTION
## Summary
Complete `docker-compose.yml` with all backing services for a fully functional local OpenMetadata instance.

## Changes
- Add MySQL 8 service with health check and persistent volume
- Add Elasticsearch 7.16.3 with single-node config
- Configure OM server with proper DB/ES connection environment variables
- Add health checks with `start_period` for OM boot time (~2 min)
- Add `depends_on` conditions (mysql healthy, ES healthy)
- Add persistent volumes for data across restarts
- Detailed comments explaining each service and usage

## Verification
```bash
curl http://localhost:8585/api/v1/system/version
# Expected: {version:x.x.x}
```

Closes #13