### PR TITLE
[P1-12] Configure OM webhook to POST to localhost:8000/webhook

### DIFF
--- a/docs/setup-webhook.md
+++ b/docs/setup-webhook.md
@@ -1,0 +1,116 @@
+# Webhook Configuration Guide
+
+This guide explains how to configure OpenMetadata to send change events to the Pulse API.
+
+## Automated Setup (Recommended)
+
+Run the configuration script after OpenMetadata is up:
+
+```bash
+# For local development (OM and Pulse both on localhost)
+python scripts/configure_webhook.py
+
+# For Docker Compose setup (services on Docker network)
+python scripts/configure_webhook.py --docker
+```
+
+The script will:
+1. Verify OpenMetadata is reachable
+2. Check if the webhook already exists (idempotent)
+3. Create or update the webhook with the correct endpoint
+4. Enable all relevant event types
+
+## Manual Setup via OM UI
+
+If you prefer to configure the webhook manually:
+
+### Step 1: Open OpenMetadata Settings
+
+1. Navigate to `http://localhost:8585` in your browser
+2. Log in with admin credentials (default: `admin` / `admin`)
+3. Click the **⚙️ Settings** gear icon in the left sidebar
+4. Under **Integrations**, click **Webhooks**
+
+### Step 2: Create a New Webhook
+
+1. Click **+ Add Webhook** button
+2. Fill in the following fields:
+
+| Field | Value |
+|-------|-------|
+| **Name** | `pulse-webhook` |
+| **Display Name** | `Pulse Webhook` |
+| **Endpoint URL** | `http://pulse-api:8000/webhook` (Docker) or `http://localhost:8000/webhook` (local) |
+| **Description** | Sends OM change events to Pulse API |
+| **Batch Size** | `10` |
+| **Timeout** | `10` seconds |
+| **Enabled** | ✅ Yes |
+
+### Step 3: Configure Event Filters
+
+Enable the following event types:
+
+- ✅ `entityCreated` — Triggers when new tables, databases, etc. are created
+- ✅ `entityUpdated` — Triggers when entity metadata changes (owner, tags, description)
+- ✅ `entityDeleted` — Triggers when entities are deleted
+- ✅ `entitySoftDeleted` — Triggers when entities are soft-deleted
+- ✅ `testCaseResult` — Triggers when data quality test results are recorded
+
+### Step 4: Save and Test
+
+1. Click **Save** to create the webhook
+2. Go to OpenMetadata and create a new table or modify an existing entity
+3. Check the Pulse API logs for the webhook event:
+
+```bash
+# Check logs
+docker-compose logs -f pulse-api | grep webhook_received
+```
+
+You should see log entries like:
+```
+event_type=entityCreated entity_type=table
+```
+
+## Endpoint URLs
+
+| Environment | Webhook Endpoint URL |
+|-------------|---------------------|
+| **Docker Compose** | `http://pulse-api:8000/webhook` |
+| **Local Development** | `http://localhost:8000/webhook` |
+
+> **Note:** When running in Docker Compose, use the Docker service name (`pulse-api`)
+> instead of `localhost`, as OM and Pulse are on the same Docker network.
+
+## Troubleshooting
+
+### Webhook not receiving events
+
+1. **Verify OM is running:**
+   ```bash
+   curl http://localhost:8585/api/v1/system/version
+   ```
+
+2. **Verify Pulse API is running:**
+   ```bash
+   curl http://localhost:8000/
+   ```
+
+3. **Check webhook status in OM:**
+   ```bash
+   curl http://localhost:8585/api/v1/webhook/name/pulse-webhook
+   ```
+
+4. **Check for network issues (Docker):**
+   ```bash
+   docker-compose exec openmetadata curl http://pulse-api:8000/
+   ```
+
+### Common Errors
+
+| Error | Solution |
+|-------|----------|
+| Connection refused | Ensure Pulse API is running and the port is correct |
+| 404 Not Found | Verify the endpoint URL path is `/webhook` |
+| Timeout | Increase the webhook timeout in OM settings |
+| Auth error | Check `OM_API_TOKEN` is set correctly |

--- a/scripts/configure_webhook.py
+++ b/scripts/configure_webhook.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Configure OpenMetadata webhook to POST events to the Pulse API.
+
+Usage:
+    python scripts/configure_webhook.py [--docker]
+
+    --docker    Use Docker network URL (http://pulse-api:8000/webhook)
+                Default uses localhost (http://localhost:8000/webhook)
+
+This script:
+1. Authenticates with OpenMetadata using JWT token
+2. Checks if a 'pulse-webhook' already exists
+3. Creates (or updates) the webhook to point to the Pulse API
+4. Enables entityCreated, entityUpdated, entityDeleted, testCaseResult events
+
+Prerequisites:
+    - OpenMetadata must be running at OM_SERVER_URL (default: http://localhost:8585)
+    - Set OM_API_TOKEN in your .env or environment
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import httpx
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+DEFAULT_OM_URL = "http://localhost:8585"
+WEBHOOK_NAME = "pulse-webhook"
+LOCAL_ENDPOINT = "http://localhost:8000/webhook"
+DOCKER_ENDPOINT = "http://pulse-api:8000/webhook"
+
+# Event types to subscribe to
+EVENT_FILTERS = [
+    "entityCreated",
+    "entityUpdated",
+    "entityDeleted",
+    "entitySoftDeleted",
+    "testCaseResult",
+]
+
+
+def get_env_config() -> tuple[str, str]:
+    """Read OM config from environment or .env file."""
+    import os
+    from pathlib import Path
+
+    # Try loading from .env file
+    env_path = Path(__file__).parent.parent / ".env"
+    env_vars: dict[str, str] = {}
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                key, _, value = line.partition("=")
+                env_vars[key.strip()] = value.strip()
+
+    om_url = os.getenv("OM_SERVER_URL", env_vars.get("OM_SERVER_URL", DEFAULT_OM_URL))
+    om_token = os.getenv("OM_API_TOKEN", env_vars.get("OM_API_TOKEN", ""))
+
+    return om_url, om_token
+
+
+def get_auth_headers(token: str) -> dict[str, str]:
+    """Build authentication headers."""
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def check_existing_webhook(
+    client: httpx.Client, om_url: str, headers: dict[str, str]
+) -> dict | None:
+    """Check if the pulse-webhook already exists."""
+    try:
+        resp = client.get(
+            f"{om_url}/api/v1/webhook/name/{WEBHOOK_NAME}",
+            headers=headers,
+        )
+        if resp.status_code == 200:
+            return resp.json()
+    except httpx.HTTPError:
+        pass
+    return None
+
+
+def create_webhook(
+    client: httpx.Client,
+    om_url: str,
+    headers: dict[str, str],
+    endpoint: str,
+) -> dict:
+    """Create the webhook in OpenMetadata."""
+    payload = {
+        "name": WEBHOOK_NAME,
+        "displayName": "Pulse Webhook",
+        "description": "Sends OpenMetadata change events to the Pulse API for notifications and dashboard updates.",
+        "endpoint": endpoint,
+        "eventFilters": [
+            {
+                "entityType": "all",
+                "filters": [
+                    {"eventType": evt, "include": ["all"]}
+                    for evt in EVENT_FILTERS
+                ],
+            }
+        ],
+        "batchSize": 10,
+        "timeout": 10,
+        "enabled": True,
+        "secretKey": "",
+    }
+
+    resp = client.post(
+        f"{om_url}/api/v1/webhook",
+        json=payload,
+        headers=headers,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def update_webhook(
+    client: httpx.Client,
+    om_url: str,
+    headers: dict[str, str],
+    existing: dict,
+    endpoint: str,
+) -> dict:
+    """Update an existing webhook."""
+    existing["endpoint"] = endpoint
+    existing["enabled"] = True
+
+    resp = client.put(
+        f"{om_url}/api/v1/webhook",
+        json=existing,
+        headers=headers,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Configure OM webhook for Pulse")
+    parser.add_argument(
+        "--docker",
+        action="store_true",
+        help="Use Docker network URL instead of localhost",
+    )
+    args = parser.parse_args()
+
+    endpoint = DOCKER_ENDPOINT if args.docker else LOCAL_ENDPOINT
+    om_url, om_token = get_env_config()
+    headers = get_auth_headers(om_token)
+
+    print(f"🔧 Configuring webhook...")
+    print(f"   OM URL:    {om_url}")
+    print(f"   Endpoint:  {endpoint}")
+    print(f"   Events:    {', '.join(EVENT_FILTERS)}")
+    print()
+
+    with httpx.Client(timeout=30) as client:
+        # Check OM is reachable
+        try:
+            resp = client.get(f"{om_url}/api/v1/system/version", headers=headers)
+            resp.raise_for_status()
+            version = resp.json().get("version", "unknown")
+            print(f"✅ Connected to OpenMetadata v{version}")
+        except httpx.HTTPError as e:
+            print(f"❌ Cannot reach OpenMetadata at {om_url}: {e}")
+            sys.exit(1)
+
+        # Check if webhook exists
+        existing = check_existing_webhook(client, om_url, headers)
+
+        try:
+            if existing:
+                print(f"📝 Updating existing webhook '{WEBHOOK_NAME}'...")
+                result = update_webhook(client, om_url, headers, existing, endpoint)
+            else:
+                print(f"🆕 Creating webhook '{WEBHOOK_NAME}'...")
+                result = create_webhook(client, om_url, headers, endpoint)
+
+            print(f"✅ Webhook configured successfully!")
+            print(f"   ID:       {result.get('id', 'N/A')}")
+            print(f"   Endpoint: {result.get('endpoint', 'N/A')}")
+            print(f"   Enabled:  {result.get('enabled', 'N/A')}")
+        except httpx.HTTPStatusError as e:
+            print(f"❌ Failed to configure webhook: {e.response.status_code}")
+            print(f"   Response: {e.response.text}")
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Add automated webhook configuration script and comprehensive documentation.

## Changes
- `scripts/configure_webhook.py` — Automated webhook setup
  - Supports both Docker (`--docker`) and local endpoints
  - Idempotent: checks if webhook exists before creating
  - Enables entityCreated, entityUpdated, entityDeleted, testCaseResult events
- `docs/setup-webhook.md` — Comprehensive guide
  - Automated and manual (UI) setup instructions
  - Endpoint URL reference table
  - Troubleshooting section

Closes #14