### PR TITLE
feat(webhook): implement production-ready POST /webhook with Pydantic validation (#9)

### DIFF
--- a/src/pulse/webhook_receiver.py
+++ b/src/pulse/webhook_receiver.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 import structlog
 from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ValidationError
 
 from pulse.notifier import dispatch_event
 
@@ -13,14 +15,66 @@ logger = structlog.get_logger(__name__)
 
 router = APIRouter()
 
+# ---------------------------------------------------------------------------
+# Pydantic model for OM change-event payloads
+# ---------------------------------------------------------------------------
+
+SUPPORTED_EVENT_TYPES = (
+    "entityCreated",
+    "entityUpdated",
+    "entityDeleted",
+    "entitySoftDeleted",
+    "testCaseResult",
+)
+
+
+class OMChangeEvent(BaseModel, extra="allow"):
+    """Typed model for an OpenMetadata change-event webhook payload.
+
+    ``extra='allow'`` ensures forward-compatibility: any additional
+    fields that OM sends in future versions are preserved and passed
+    downstream without breaking validation.
+    """
+
+    eventType: Literal[
+        "entityCreated",
+        "entityUpdated",
+        "entityDeleted",
+        "entitySoftDeleted",
+        "testCaseResult",
+    ]
+    entityType: str
+    entityFullyQualifiedName: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Webhook endpoint
+# ---------------------------------------------------------------------------
+
 
 @router.post("/webhook")
 async def receive_webhook(request: Request) -> dict[str, str]:
-    """Accept an OM change-event webhook payload."""
-    payload: dict[str, Any] = await request.json()
-    event_type = payload.get("eventType", "unknown")
-    entity_type = payload.get("entityType", "unknown")
-    logger.info("webhook_received", event_type=event_type, entity_type=entity_type)
+    """Accept an OM change-event webhook payload.
 
-    await dispatch_event(payload)
+    Returns 200 on success, 400 on malformed / invalid payload.
+    """
+    body: dict[str, Any] = await request.json()
+
+    try:
+        event = OMChangeEvent(**body)
+    except ValidationError as exc:
+        logger.warning("webhook_validation_error", errors=exc.errors())
+        return JSONResponse(  # type: ignore[return-value]
+            status_code=400,
+            content={"detail": exc.errors()},
+        )
+
+    logger.info(
+        "webhook_received",
+        event_type=event.eventType,
+        entity_type=event.entityType,
+        fqn=event.entityFullyQualifiedName,
+    )
+
+    await dispatch_event(event.model_dump())
     return {"status": "ok"}

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,22 +1,171 @@
 """Tests for the webhook receiver endpoint."""
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from fastapi.testclient import TestClient
 
 from pulse.server import app
+from pulse.webhook_receiver import OMChangeEvent
 
 client = TestClient(app)
 
+# ---------------------------------------------------------------------------
+# Valid payload helpers
+# ---------------------------------------------------------------------------
 
-def test_webhook_accepts_event():
+_VALID_PAYLOADS = [
+    {
+        "eventType": "entityCreated",
+        "entityType": "table",
+        "entityFullyQualifiedName": "sample.public.orders",
+    },
+    {
+        "eventType": "entityUpdated",
+        "entityType": "topic",
+        "entityFullyQualifiedName": "kafka.events",
+    },
+    {
+        "eventType": "entityDeleted",
+        "entityType": "dashboard",
+        "entityFullyQualifiedName": "superset.revenue",
+    },
+    {
+        "eventType": "entitySoftDeleted",
+        "entityType": "pipeline",
+        "entityFullyQualifiedName": "airflow.etl_daily",
+    },
+    {
+        "eventType": "testCaseResult",
+        "entityType": "testCase",
+        "entityFullyQualifiedName": "sample.public.orders.row_count",
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Tests — valid payloads (all 5 event types)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("payload", _VALID_PAYLOADS, ids=[
+    p["eventType"] for p in _VALID_PAYLOADS
+])
+def test_webhook_accepts_all_event_types(payload):
+    """POST /webhook returns 200 for every supported OM event type."""
+    resp = client.post("/webhook", json=payload)
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# Tests — malformed / invalid payloads → 400
+# ---------------------------------------------------------------------------
+
+
+def test_webhook_rejects_missing_event_type():
+    """Missing required `eventType` returns 400."""
+    payload = {"entityType": "table", "entityFullyQualifiedName": "x.y.z"}
+    resp = client.post("/webhook", json=payload)
+    assert resp.status_code == 400
+    assert "detail" in resp.json()
+
+
+def test_webhook_rejects_invalid_event_type():
+    """An unsupported eventType value returns 400."""
+    payload = {
+        "eventType": "entityMutated",
+        "entityType": "table",
+        "entityFullyQualifiedName": "x.y.z",
+    }
+    resp = client.post("/webhook", json=payload)
+    assert resp.status_code == 400
+    assert "detail" in resp.json()
+
+
+def test_webhook_rejects_empty_body():
+    """An empty JSON object returns 400."""
+    resp = client.post("/webhook", json={})
+    assert resp.status_code == 400
+    assert "detail" in resp.json()
+
+
+def test_webhook_rejects_missing_entity_type():
+    """Missing required `entityType` returns 400."""
+    payload = {"eventType": "entityCreated"}
+    resp = client.post("/webhook", json=payload)
+    assert resp.status_code == 400
+    assert "detail" in resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Tests — notifier integration
+# ---------------------------------------------------------------------------
+
+
+def test_webhook_passes_event_to_notifier():
+    """Valid payload is forwarded to notifier.dispatch_event()."""
+    mock_dispatch = AsyncMock()
     payload = {
         "eventType": "entityCreated",
         "entityType": "table",
         "entityFullyQualifiedName": "sample.public.orders",
     }
-    resp = client.post("/webhook", json=payload)
+    with patch("pulse.webhook_receiver.dispatch_event", mock_dispatch):
+        resp = client.post("/webhook", json=payload)
+
     assert resp.status_code == 200
-    assert resp.json() == {"status": "ok"}
+    mock_dispatch.assert_called_once()
+    dispatched = mock_dispatch.call_args[0][0]
+    assert dispatched["eventType"] == "entityCreated"
+    assert dispatched["entityType"] == "table"
+    assert dispatched["entityFullyQualifiedName"] == "sample.public.orders"
+
+
+def test_webhook_preserves_extra_fields():
+    """Extra fields from OM are preserved and passed to the notifier."""
+    mock_dispatch = AsyncMock()
+    payload = {
+        "eventType": "entityUpdated",
+        "entityType": "table",
+        "entityFullyQualifiedName": "db.schema.users",
+        "previousVersion": 0.1,
+        "currentVersion": 0.2,
+    }
+    with patch("pulse.webhook_receiver.dispatch_event", mock_dispatch):
+        resp = client.post("/webhook", json=payload)
+
+    assert resp.status_code == 200
+    dispatched = mock_dispatch.call_args[0][0]
+    assert dispatched["previousVersion"] == 0.1
+    assert dispatched["currentVersion"] == 0.2
+
+
+# ---------------------------------------------------------------------------
+# Tests — Pydantic model unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_om_change_event_model_valid():
+    """OMChangeEvent accepts a valid payload."""
+    event = OMChangeEvent(
+        eventType="entityCreated",
+        entityType="table",
+        entityFullyQualifiedName="sample.public.orders",
+    )
+    assert event.eventType == "entityCreated"
+    assert event.entityType == "table"
+
+
+def test_om_change_event_model_defaults_fqn():
+    """entityFullyQualifiedName defaults to empty string."""
+    event = OMChangeEvent(eventType="entityDeleted", entityType="topic")
+    assert event.entityFullyQualifiedName == ""
+
+
+# ---------------------------------------------------------------------------
+# Tests — root endpoint (pre-existing)
+# ---------------------------------------------------------------------------
 
 
 def test_root_endpoint():


### PR DESCRIPTION
## Summary

Implements a production-ready `POST /webhook` endpoint in `webhook_receiver.py` with Pydantic-based payload validation, structured logging, and comprehensive error handling.

**Closes #9**

## Changes

### `src/pulse/webhook_receiver.py`

- **Added `OMChangeEvent` Pydantic model** with:
  - `eventType` validated via `Literal` against 5 supported OM event types (`entityCreated`, `entityUpdated`, `entityDeleted`, `entitySoftDeleted`, `testCaseResult`)
  - `entityType` — required string field
  - `entityFullyQualifiedName` — optional, defaults to `""`
  - `extra="allow"` for forward-compatibility with future OM fields
  
- **Replaced raw `request.json()` with Pydantic validation** — malformed/invalid payloads now return `400` with structured error details instead of crashing with `500`

- **Enhanced structured logging** — logs `event_type`, `entity_type`, and `fqn` on every received event; logs validation errors as warnings

- **Passes validated event** to `notifier.dispatch_event()` via `model_dump()`

### `tests/test_webhook.py`

Expanded test suite from **2 → 14 tests**:

| Category | Tests |
|----------|-------|
| Valid payloads (all 5 event types) | 5 parametrized tests |
| Malformed/invalid payloads → 400 | 4 tests (missing eventType, invalid eventType, empty body, missing entityType) |
| Notifier integration | 2 tests (dispatch verification, extra field preservation) |
| Pydantic model unit tests | 2 tests (valid model, FQN default) |
| Root endpoint | 1 test (pre-existing) |

## Acceptance Criteria ✅

- [x] `OMChangeEvent` Pydantic model validates incoming payloads
- [x] Malformed payloads return 400 with error detail
- [x] Valid payloads pass to `notifier.dispatch_event()` and return 200
- [x] Handles all OM event types: entityCreated, entityUpdated, entityDeleted, entitySoftDeleted, testCaseResult
- [x] Async request processing, `structlog` logging

## Test Results

```
============================= 16 passed in 6.90s ==============================
tests/test_notifier.py::test_format_slack_blocks_schema_change PASSED
tests/test_notifier.py::test_format_slack_blocks_entity_created PASSED
tests/test_webhook.py::test_webhook_accepts_all_event_types[entityCreated] PASSED
tests/test_webhook.py::test_webhook_accepts_all_event_types[entityUpdated] PASSED
tests/test_webhook.py::test_webhook_accepts_all_event_types[entityDeleted] PASSED
tests/test_webhook.py::test_webhook_accepts_all_event_types[entitySoftDeleted] PASSED
tests/test_webhook.py::test_webhook_accepts_all_event_types[testCaseResult] PASSED
tests/test_webhook.py::test_webhook_rejects_missing_event_type PASSED
tests/test_webhook.py::test_webhook_rejects_invalid_event_type PASSED
tests/test_webhook.py::test_webhook_rejects_empty_body PASSED
tests/test_webhook.py::test_webhook_rejects_missing_entity_type PASSED
tests/test_webhook.py::test_webhook_passes_event_to_notifier PASSED
tests/test_webhook.py::test_webhook_preserves_extra_fields PASSED
tests/test_webhook.py::test_om_change_event_model_valid PASSED
tests/test_webhook.py::test_om_change_event_model_defaults_fqn PASSED
tests/test_webhook.py::test_root_endpoint PASSED
```