### PR TITLE
[P1-05] Verify /pulse health end-to-end in Slack

### DIFF
--- a/Progress.md
+++ b/Progress.md
@@ -84,7 +84,7 @@ Per-person, per-phase progress on every task in [TaskSync.md](./TaskSync.md). On
 | P1-02   | Create project structure (`src/pulse/...`, `ui/`, `tests/`)|       |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
 | P1-03   | Implement `om_client.py`: MCP wrapper for search + details |       |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
 | P1-04   | Implement `bot.py`: Slack bolt app + `/pulse` command      | 6     | 27  | [x] | [x] | [x] | [ ] | [ ] | [x] | [x] | [x] |
-| P1-05   | Verify `/pulse health` works in Slack                      |       |     | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
+| P1-05   | Verify `/pulse health` works in Slack                      | 7     |     | [x] | [x] | [x] | [ ] | [ ] | [ ] | [ ] | [ ] |
 | P1-06   | Review all Phase 1 PRs                                     |       | n/a | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] | [ ] |
 
 ### @Chellammal-K

--- a/TaskSync.md
+++ b/TaskSync.md
@@ -71,7 +71,7 @@ We'll link the final submission + demo video before the Apr 26 deadline.
   ```
 - [ ] `P1-03` Implement `om_client.py`: connect to OM MCP, wrap `search_metadata` + `get_entity_details`
 - [ ] `P1-04` Implement `bot.py`: Slack bolt app, register `/pulse` slash command, health check response
-- [ ] `P1-05` Verify: `/pulse health` in Slack returns "Pulse is alive, connected to OM at :8585"
+- [x] `P1-05` Verify: `/pulse health` in Slack returns "Pulse is alive, connected to OM at :8585"
 - [ ] `P1-06` Review all Phase 1 PRs
 
 ### DD-CHK (@Chellammal-K) — Senior Builder

--- a/src/pulse/bot.py
+++ b/src/pulse/bot.py
@@ -106,19 +106,10 @@ def _health_check() -> str:
             results = asyncio.run(search_metadata("*", limit=1))
 
         logger.info("health_check_success", om_url=settings.om_server_url, hits=len(results))
-        return (
-            f":white_check_mark: *Pulse is healthy!*\n"
-            f"• Connected to OpenMetadata at `{settings.om_server_url}`\n"
-            f"• Search API responding — {len(results)} result(s) returned"
-        )
+        return f"✅ Pulse is alive, connected to OM at `{settings.om_server_url}`"
     except Exception as exc:
         logger.error("health_check_failed", om_url=settings.om_server_url, error=str(exc))
-        return (
-            f":x: *OM connectivity issue*\n"
-            f"• Cannot reach OpenMetadata at `{settings.om_server_url}`\n"
-            f"• Error: `{exc!s}`\n"
-            f"• Check that OM is running and `OM_SERVER_URL` / `OM_API_TOKEN` are correct."
-        )
+        return f"❌ Cannot reach OpenMetadata at `{settings.om_server_url}`"
 
 
 def _handle_ask(respond, args: str) -> None:  # noqa: ANN001

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -101,15 +101,14 @@ class TestHealthCheck:
             mock_search.return_value = [{"_source": {"name": "test"}}]
             result = _health_check()
 
-        assert "healthy" in result.lower() or "check_mark" in result
-        assert "1 result" in result
+        assert "✅ Pulse is alive" in result
 
     def test_unhealthy_response(self):
         with patch("pulse.bot.search_metadata", new_callable=AsyncMock) as mock_search:
             mock_search.side_effect = ConnectionError("Connection refused")
             result = _health_check()
 
-        assert "connectivity issue" in result.lower() or ":x:" in result
+        assert "❌ Cannot reach OpenMetadata" in result
 
 
 class TestAskHandler:


### PR DESCRIPTION
Updates bot response to match the exact strings specified in the acceptance criteria. Updates tests, TaskSync.md, and Progress.md accordingly. Closes #7.