### PR TITLE
feat(templates): Map OM event types to specialized Slack Block Kit templates (#11)

### DIFF
--- a/src/pulse/notifier.py
+++ b/src/pulse/notifier.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import re
-from datetime import datetime, timezone
 from typing import Any
 
 import structlog
@@ -11,6 +9,7 @@ from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
 from pulse.config import settings
+from pulse.templates import EVENT_EMOJI, _humanize_event_type, route_payload_to_template
 
 logger = structlog.get_logger(__name__)
 
@@ -30,111 +29,6 @@ def _get_slack_client() -> WebClient | None:
         _slack_client = WebClient(token=settings.slack_bot_token)
         return _slack_client
     return None
-
-
-# ---------------------------------------------------------------------------
-# Event type → emoji mapping
-# ---------------------------------------------------------------------------
-
-EVENT_EMOJI: dict[str, str] = {
-    "entityCreated": ":new:",
-    "entityUpdated": ":pencil2:",
-    "entityDeleted": ":wastebasket:",
-    "entitySoftDeleted": ":ghost:",
-    "testCaseResult": ":test_tube:",
-}
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _humanize_event_type(event_type: str) -> str:
-    """Convert camelCase event type to a human-readable title.
-
-    Example: ``entityCreated`` → ``Entity Created``
-    """
-    # Insert a space before each uppercase letter, then title-case
-    spaced = re.sub(r"([A-Z])", r" \1", event_type).strip()
-    return spaced.title()
-
-
-def _build_om_url(entity_type: str, fqn: str) -> str:
-    """Construct a deep-link URL to an entity in the OpenMetadata UI."""
-    base = settings.om_server_url.rstrip("/")
-    return f"{base}/{entity_type}/{fqn}"
-
-
-# ---------------------------------------------------------------------------
-# Block Kit builder
-# ---------------------------------------------------------------------------
-
-
-def _format_slack_blocks(
-    emoji: str, event_type: str, entity_type: str, fqn: str
-) -> list[dict[str, Any]]:
-    """Build rich Slack Block Kit blocks for a change event.
-
-    Layout:
-        1. Header  — emoji + human-readable event title
-        2. Section — entity details with clickable OM deep-link
-        3. Context — timestamp + event-type badge
-        4. Actions — "View in OpenMetadata" button
-    """
-    human_event = _humanize_event_type(event_type)
-    om_url = _build_om_url(entity_type, fqn)
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-
-    blocks: list[dict[str, Any]] = [
-        # 1. Header
-        {
-            "type": "header",
-            "text": {
-                "type": "plain_text",
-                "text": f"{emoji} {human_event}",
-                "emoji": True,
-            },
-        },
-        # 2. Section — entity info with deep-link
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": (
-                    f"*Entity Type:* `{entity_type}`\n"
-                    f"*FQN:* <{om_url}|{fqn}>"
-                ),
-            },
-        },
-        # 3. Context — timestamp + badge
-        {
-            "type": "context",
-            "elements": [
-                {
-                    "type": "mrkdwn",
-                    "text": f":clock1: {now}  |  `{event_type}`",
-                },
-            ],
-        },
-        # 4. Actions — View in OM button
-        {
-            "type": "actions",
-            "elements": [
-                {
-                    "type": "button",
-                    "text": {
-                        "type": "plain_text",
-                        "text": "View in OpenMetadata",
-                        "emoji": True,
-                    },
-                    "url": om_url,
-                    "action_id": "view_in_om",
-                },
-            ],
-        },
-    ]
-
-    return blocks
 
 
 # ---------------------------------------------------------------------------
@@ -160,7 +54,7 @@ async def dispatch_event(payload: dict[str, Any]) -> None:
         fqn=entity_fqn,
     )
 
-    blocks = _format_slack_blocks(emoji, event_type, entity_type, entity_fqn)
+    blocks = route_payload_to_template(payload)
     fallback_text = f"{emoji} {_humanize_event_type(event_type)} on {entity_type}: {entity_fqn}"
 
     client = _get_slack_client()

--- a/src/pulse/templates.py
+++ b/src/pulse/templates.py
@@ -1,0 +1,292 @@
+"""Slack Block Kit templates for OpenMetadata event types."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+from pulse.config import settings
+
+# ---------------------------------------------------------------------------
+# Event type → emoji mapping
+# ---------------------------------------------------------------------------
+
+EVENT_EMOJI: dict[str, str] = {
+    "entityCreated": ":new:",
+    "entityUpdated": ":pencil2:",
+    "entityDeleted": ":wastebasket:",
+    "entitySoftDeleted": ":ghost:",
+    "testCaseResult": ":test_tube:",
+}
+
+# ---------------------------------------------------------------------------
+# Core Helpers
+# ---------------------------------------------------------------------------
+
+
+def _humanize_event_type(event_type: str) -> str:
+    """Convert camelCase event type to a human-readable title."""
+    spaced = re.sub(r"([A-Z])", r" \1", event_type).strip()
+    return spaced.title()
+
+
+def _build_om_url(entity_type: str, fqn: str) -> str:
+    """Construct a deep-link URL to an entity in the OpenMetadata UI."""
+    base = settings.om_server_url.rstrip("/")
+    return f"{base}/{entity_type}/{fqn}"
+
+
+def _safe_json_loads(val: Any) -> Any:
+    """Attempt to parse a string as JSON; return the original if parsing fails."""
+    if isinstance(val, str):
+        try:
+            return json.loads(val)
+        except json.JSONDecodeError:
+            pass
+    return val
+
+
+def _build_base_blocks(
+    emoji: str, event_type: str, entity_type: str, fqn: str
+) -> list[dict[str, Any]]:
+    """Build the common Header, Section, and Context blocks."""
+    human_event = _humanize_event_type(event_type)
+    om_url = _build_om_url(entity_type, fqn)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    return [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": f"{emoji} {human_event}",
+                "emoji": True,
+            },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*Entity Type:* `{entity_type}`\n*FQN:* <{om_url}|{fqn}>",
+            },
+        },
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": f":clock1: {now}  |  `{event_type}`",
+                },
+            ],
+        },
+    ]
+
+
+def _append_action_block(blocks: list[dict[str, Any]], entity_type: str, fqn: str) -> list[dict[str, Any]]:
+    """Append the standard 'View in OpenMetadata' button block."""
+    om_url = _build_om_url(entity_type, fqn)
+    blocks.append({
+        "type": "actions",
+        "elements": [
+            {
+                "type": "button",
+                "text": {
+                    "type": "plain_text",
+                    "text": "View in OpenMetadata",
+                    "emoji": True,
+                },
+                "url": om_url,
+                "action_id": "view_in_om",
+            },
+        ],
+    })
+    return blocks
+
+
+# ---------------------------------------------------------------------------
+# Template Functions
+# ---------------------------------------------------------------------------
+
+
+def template_schema_change(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Template for schema changes (columns added/removed/modified)."""
+    event_type = payload.get("eventType", "unknown")
+    entity_type = payload.get("entityType", "unknown")
+    fqn = payload.get("entityFullyQualifiedName", "")
+    emoji = EVENT_EMOJI.get(event_type, ":bell:")
+
+    blocks = _build_base_blocks(emoji, event_type, entity_type, fqn)
+    
+    change_desc = payload.get("changeDescription", {})
+    diff_text = ""
+    
+    for change_type in ["fieldsAdded", "fieldsDeleted", "fieldsUpdated"]:
+        for field in change_desc.get(change_type, []):
+            if field.get("name") == "columns":
+                old_val = _safe_json_loads(field.get("oldValue", "[]"))
+                new_val = _safe_json_loads(field.get("newValue", "[]"))
+                
+                # Truncate stringification to prevent oversized Slack blocks
+                old_str = str(old_val)[:500]
+                new_str = str(new_val)[:500]
+                
+                diff_text += f"*{change_type.replace('fields', '')}:*\n`Old:` {old_str}\n`New:` {new_str}\n\n"
+
+    if diff_text:
+        blocks.insert(2, {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": diff_text.strip()[:3000]}
+        })
+
+    return _append_action_block(blocks, entity_type, fqn)
+
+
+def template_dq_failure(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Template for DQ test failures."""
+    event_type = payload.get("eventType", "unknown")
+    entity_type = payload.get("entityType", "unknown")
+    fqn = payload.get("entityFullyQualifiedName", "")
+    emoji = EVENT_EMOJI.get(event_type, ":bell:")
+
+    blocks = _build_base_blocks(emoji, event_type, entity_type, fqn)
+    
+    test_case_res = payload.get("testCaseResult", {})
+    status = test_case_res.get("testCaseStatus", "Failed")
+    result_str = test_case_res.get("result", "N/A")
+    
+    blocks.insert(2, {
+        "type": "section",
+        "fields": [
+            {"type": "mrkdwn", "text": f"*Status:*\n`{status}`"},
+            {"type": "mrkdwn", "text": f"*Result:*\n{result_str[:1500]}"},
+        ]
+    })
+    
+    return _append_action_block(blocks, entity_type, fqn)
+
+
+def template_entity_created(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Template for newly created assets."""
+    event_type = payload.get("eventType", "unknown")
+    entity_type = payload.get("entityType", "unknown")
+    fqn = payload.get("entityFullyQualifiedName", "")
+    emoji = EVENT_EMOJI.get(event_type, ":bell:")
+
+    blocks = _build_base_blocks(emoji, event_type, entity_type, fqn)
+    
+    owner_info = payload.get("owner")
+    owner_name = "Unowned"
+    if isinstance(owner_info, dict):
+        owner_name = owner_info.get("name", "Unowned")
+        
+    tags = payload.get("tags", [])
+    tier_str = next((tag.get("tagFQN") for tag in tags if tag.get("tagFQN", "").startswith("Tier")), "No Tier")
+
+    blocks.insert(2, {
+        "type": "section",
+        "fields": [
+            {"type": "mrkdwn", "text": f"*Owner:*\n{owner_name}"},
+            {"type": "mrkdwn", "text": f"*Tier:*\n{tier_str}"},
+        ]
+    })
+    
+    return _append_action_block(blocks, entity_type, fqn)
+
+
+def template_ownership_change(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Template for ownership changes."""
+    event_type = payload.get("eventType", "unknown")
+    entity_type = payload.get("entityType", "unknown")
+    fqn = payload.get("entityFullyQualifiedName", "")
+    emoji = EVENT_EMOJI.get(event_type, ":bell:")
+
+    blocks = _build_base_blocks(emoji, event_type, entity_type, fqn)
+    
+    change_desc = payload.get("changeDescription", {})
+    diff_text = ""
+    for field in change_desc.get("fieldsUpdated", []):
+        if field.get("name") == "owner":
+            old_val = _safe_json_loads(field.get("oldValue", "{}"))
+            new_val = _safe_json_loads(field.get("newValue", "{}"))
+            
+            old_name = old_val.get("name", "Unknown") if isinstance(old_val, dict) else str(old_val)
+            new_name = new_val.get("name", "Unknown") if isinstance(new_val, dict) else str(new_val)
+            
+            diff_text = f"Changed from `{old_name}` to `{new_name}`"
+
+    if diff_text:
+        blocks.insert(2, {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": diff_text}
+        })
+
+    return _append_action_block(blocks, entity_type, fqn)
+
+
+def template_entity_deleted(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Template for deleted assets."""
+    event_type = payload.get("eventType", "unknown")
+    entity_type = payload.get("entityType", "unknown")
+    fqn = payload.get("entityFullyQualifiedName", "")
+    emoji = EVENT_EMOJI.get(event_type, ":bell:")
+
+    blocks = _build_base_blocks(emoji, event_type, entity_type, fqn)
+    
+    updated_by = payload.get("updatedBy", "Unknown")
+    
+    blocks.insert(2, {
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": f"Entity was removed by `{updated_by}`."}
+    })
+    
+    return _append_action_block(blocks, entity_type, fqn)
+
+
+def template_generic(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Fallback template for generic updates."""
+    event_type = payload.get("eventType", "unknown")
+    entity_type = payload.get("entityType", "unknown")
+    fqn = payload.get("entityFullyQualifiedName", "")
+    emoji = EVENT_EMOJI.get(event_type, ":bell:")
+
+    blocks = _build_base_blocks(emoji, event_type, entity_type, fqn)
+    return _append_action_block(blocks, entity_type, fqn)
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+def route_payload_to_template(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Determine the correct template and generate Slack blocks for the payload."""
+    event_type = payload.get("eventType", "unknown")
+    
+    if event_type == "entityCreated":
+        return template_entity_created(payload)
+    
+    elif event_type in ("entityDeleted", "entitySoftDeleted"):
+        return template_entity_deleted(payload)
+        
+    elif event_type == "testCaseResult":
+        return template_dq_failure(payload)
+        
+    elif event_type == "entityUpdated":
+        # Need to check changeDescription to see if it's schema or ownership
+        change_desc = payload.get("changeDescription", {})
+        
+        # Check ownership first
+        for field in change_desc.get("fieldsUpdated", []):
+            if field.get("name") == "owner":
+                return template_ownership_change(payload)
+                
+        # Check schema (columns)
+        for change_type in ("fieldsAdded", "fieldsDeleted", "fieldsUpdated"):
+            for field in change_desc.get(change_type, []):
+                if field.get("name") == "columns":
+                    return template_schema_change(payload)
+                    
+        return template_generic(payload)
+        
+    # Fallback
+    return template_generic(payload)

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,137 +1,11 @@
-"""Tests for the notification engine."""
+"""Tests for the notification engine dispatcher."""
 
-from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
 from slack_sdk.errors import SlackApiError
 
-from pulse.notifier import (
-    EVENT_EMOJI,
-    _build_om_url,
-    _format_slack_blocks,
-    _humanize_event_type,
-    dispatch_event,
-)
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def test_humanize_entity_created():
-    assert _humanize_event_type("entityCreated") == "Entity Created"
-
-
-def test_humanize_entity_updated():
-    assert _humanize_event_type("entityUpdated") == "Entity Updated"
-
-
-def test_humanize_entity_deleted():
-    assert _humanize_event_type("entityDeleted") == "Entity Deleted"
-
-
-def test_humanize_entity_soft_deleted():
-    assert _humanize_event_type("entitySoftDeleted") == "Entity Soft Deleted"
-
-
-def test_humanize_test_case_result():
-    assert _humanize_event_type("testCaseResult") == "Test Case Result"
-
-
-def test_build_om_url():
-    with patch("pulse.notifier.settings") as mock_settings:
-        mock_settings.om_server_url = "http://localhost:8585"
-        url = _build_om_url("table", "sample.public.orders")
-    assert url == "http://localhost:8585/table/sample.public.orders"
-
-
-def test_build_om_url_strips_trailing_slash():
-    with patch("pulse.notifier.settings") as mock_settings:
-        mock_settings.om_server_url = "http://localhost:8585/"
-        url = _build_om_url("topic", "kafka.events")
-    assert url == "http://localhost:8585/topic/kafka.events"
-
-
-# ---------------------------------------------------------------------------
-# Block Kit structure tests
-# ---------------------------------------------------------------------------
-
-
-def _make_blocks(
-    event_type: str = "entityCreated",
-    entity_type: str = "table",
-    fqn: str = "sample.public.orders",
-) -> list[dict]:
-    emoji = EVENT_EMOJI.get(event_type, ":bell:")
-    with patch("pulse.notifier.settings") as mock_settings:
-        mock_settings.om_server_url = "http://localhost:8585"
-        return _format_slack_blocks(emoji, event_type, entity_type, fqn)
-
-
-def test_format_blocks_returns_four_blocks():
-    """Block Kit output must contain header, section, context, actions."""
-    blocks = _make_blocks()
-    assert len(blocks) == 4
-
-
-def test_format_blocks_header_type():
-    blocks = _make_blocks()
-    assert blocks[0]["type"] == "header"
-
-
-def test_format_blocks_header_contains_emoji_and_event():
-    blocks = _make_blocks(event_type="entityCreated")
-    header_text = blocks[0]["text"]["text"]
-    assert ":new:" in header_text
-    assert "Entity Created" in header_text
-
-
-def test_format_blocks_section_contains_entity_type():
-    blocks = _make_blocks(entity_type="table")
-    section_text = blocks[1]["text"]["text"]
-    assert "`table`" in section_text
-
-
-def test_format_blocks_section_contains_fqn_link():
-    blocks = _make_blocks(fqn="sample.public.orders")
-    section_text = blocks[1]["text"]["text"]
-    assert "sample.public.orders" in section_text
-    assert "http://localhost:8585/table/sample.public.orders" in section_text
-
-
-def test_format_blocks_context_contains_timestamp_and_event_type():
-    blocks = _make_blocks(event_type="entityUpdated")
-    ctx_text = blocks[2]["elements"][0]["text"]
-    assert ":clock1:" in ctx_text
-    assert "`entityUpdated`" in ctx_text
-
-
-def test_format_blocks_actions_has_view_button():
-    blocks = _make_blocks()
-    actions = blocks[3]
-    assert actions["type"] == "actions"
-    btn = actions["elements"][0]
-    assert btn["text"]["text"] == "View in OpenMetadata"
-    assert "http://localhost:8585/table/sample.public.orders" in btn["url"]
-
-
-@pytest.mark.parametrize(
-    "event_type,expected_emoji",
-    [
-        ("entityCreated", ":new:"),
-        ("entityUpdated", ":pencil2:"),
-        ("entityDeleted", ":wastebasket:"),
-        ("entitySoftDeleted", ":ghost:"),
-        ("testCaseResult", ":test_tube:"),
-    ],
-    ids=["created", "updated", "deleted", "soft_deleted", "test_result"],
-)
-def test_format_blocks_all_event_types_have_correct_emoji(event_type, expected_emoji):
-    blocks = _make_blocks(event_type=event_type)
-    header_text = blocks[0]["text"]["text"]
-    assert expected_emoji in header_text
-
+from pulse.notifier import dispatch_event
 
 # ---------------------------------------------------------------------------
 # dispatch_event() — Slack posting tests
@@ -154,13 +28,14 @@ async def test_dispatch_event_calls_slack_post_message():
             "eventType": "entityCreated",
             "entityType": "table",
             "entityFullyQualifiedName": "sample.public.orders",
+            "owner": {"name": "Test Owner"},
         })
 
     mock_client.chat_postMessage.assert_called_once()
     call_kwargs = mock_client.chat_postMessage.call_args
     assert call_kwargs.kwargs["channel"] == "#test-channel"
     assert isinstance(call_kwargs.kwargs["blocks"], list)
-    assert len(call_kwargs.kwargs["blocks"]) == 4
+    assert len(call_kwargs.kwargs["blocks"]) > 0
     assert "Entity Created" in call_kwargs.kwargs["text"]
 
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,239 @@
+"""Tests for the Slack Block Kit templates."""
+
+from unittest.mock import patch
+
+import pytest
+
+from pulse.templates import (
+    EVENT_EMOJI,
+    _build_base_blocks,
+    _build_om_url,
+    _humanize_event_type,
+    route_payload_to_template,
+    template_dq_failure,
+    template_entity_created,
+    template_entity_deleted,
+    template_generic,
+    template_ownership_change,
+    template_schema_change,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def test_humanize_event_type():
+    assert _humanize_event_type("entityCreated") == "Entity Created"
+    assert _humanize_event_type("entitySoftDeleted") == "Entity Soft Deleted"
+    assert _humanize_event_type("testCaseResult") == "Test Case Result"
+
+def test_build_om_url():
+    with patch("pulse.templates.settings") as mock_settings:
+        mock_settings.om_server_url = "http://localhost:8585/"
+        url = _build_om_url("table", "sample.public.orders")
+    assert url == "http://localhost:8585/table/sample.public.orders"
+
+def test_build_base_blocks():
+    with patch("pulse.templates.settings") as mock_settings:
+        mock_settings.om_server_url = "http://localhost:8585"
+        blocks = _build_base_blocks(":new:", "entityCreated", "table", "db.schema.tbl")
+    
+    assert len(blocks) == 3
+    assert blocks[0]["type"] == "header"
+    assert "Entity Created" in blocks[0]["text"]["text"]
+    assert blocks[1]["type"] == "section"
+    assert "db.schema.tbl" in blocks[1]["text"]["text"]
+    assert blocks[2]["type"] == "context"
+
+# ---------------------------------------------------------------------------
+# Templates
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def base_payload():
+    return {
+        "eventType": "unknown",
+        "entityType": "table",
+        "entityFullyQualifiedName": "sample.public.orders"
+    }
+
+def test_template_entity_created(base_payload):
+    payload = {
+        **base_payload,
+        "eventType": "entityCreated",
+        "owner": {"name": "Data Team"},
+        "tags": [{"tagFQN": "Tier.Tier1"}]
+    }
+    blocks = template_entity_created(payload)
+    
+    assert len(blocks) == 5  # header, section, new section, context, actions
+    
+    # Check the custom section
+    custom_section = blocks[2]
+    assert custom_section["type"] == "section"
+    fields = custom_section["fields"]
+    assert "Data Team" in fields[0]["text"]
+    assert "Tier.Tier1" in fields[1]["text"]
+
+def test_template_entity_created_missing_fields(base_payload):
+    """Should handle missing owner/tags gracefully."""
+    payload = {**base_payload, "eventType": "entityCreated"}
+    blocks = template_entity_created(payload)
+    
+    custom_section = blocks[2]
+    assert "Unowned" in custom_section["fields"][0]["text"]
+    assert "No Tier" in custom_section["fields"][1]["text"]
+
+def test_template_entity_deleted(base_payload):
+    payload = {
+        **base_payload,
+        "eventType": "entityDeleted",
+        "updatedBy": "admin_user"
+    }
+    blocks = template_entity_deleted(payload)
+    
+    custom_section = blocks[2]
+    assert custom_section["type"] == "section"
+    assert "admin_user" in custom_section["text"]["text"]
+
+def test_template_entity_deleted_missing_fields(base_payload):
+    payload = {**base_payload, "eventType": "entityDeleted"}
+    blocks = template_entity_deleted(payload)
+    assert "Unknown" in blocks[2]["text"]["text"]
+
+def test_template_dq_failure(base_payload):
+    payload = {
+        **base_payload,
+        "eventType": "testCaseResult",
+        "testCaseResult": {
+            "testCaseStatus": "Failed",
+            "result": "Found 5 nulls, expected 0"
+        }
+    }
+    blocks = template_dq_failure(payload)
+    
+    custom_section = blocks[2]
+    assert "Failed" in custom_section["fields"][0]["text"]
+    assert "Found 5 nulls" in custom_section["fields"][1]["text"]
+
+def test_template_dq_failure_missing_fields(base_payload):
+    payload = {**base_payload, "eventType": "testCaseResult"}
+    blocks = template_dq_failure(payload)
+    
+    custom_section = blocks[2]
+    assert "Failed" in custom_section["fields"][0]["text"]
+    assert "N/A" in custom_section["fields"][1]["text"]
+
+def test_template_ownership_change(base_payload):
+    payload = {
+        **base_payload,
+        "eventType": "entityUpdated",
+        "changeDescription": {
+            "fieldsUpdated": [
+                {"name": "owner", "oldValue": '{"name": "Old Team"}', "newValue": '{"name": "New Team"}'}
+            ]
+        }
+    }
+    blocks = template_ownership_change(payload)
+    
+    custom_section = blocks[2]
+    assert "Old Team" in custom_section["text"]["text"]
+    assert "New Team" in custom_section["text"]["text"]
+
+def test_template_ownership_change_missing_fields(base_payload):
+    payload = {
+        **base_payload,
+        "eventType": "entityUpdated",
+        "changeDescription": {
+            "fieldsUpdated": [
+                {"name": "owner"} # missing old/new values
+            ]
+        }
+    }
+    blocks = template_ownership_change(payload)
+    assert "Unknown" in blocks[2]["text"]["text"]
+
+def test_template_schema_change(base_payload):
+    payload = {
+        **base_payload,
+        "eventType": "entityUpdated",
+        "changeDescription": {
+            "fieldsAdded": [
+                {"name": "columns", "newValue": '[{"name": "new_col"}]'}
+            ]
+        }
+    }
+    blocks = template_schema_change(payload)
+    
+    custom_section = blocks[2]
+    assert "Added:" in custom_section["text"]["text"]
+    assert "new_col" in custom_section["text"]["text"]
+
+def test_template_schema_change_missing_fields(base_payload):
+    payload = {
+        **base_payload,
+        "eventType": "entityUpdated",
+        "changeDescription": {
+            "fieldsAdded": [
+                {"name": "columns"} # missing newValue
+            ]
+        }
+    }
+    blocks = template_schema_change(payload)
+    assert "Added:" in blocks[2]["text"]["text"]
+    assert "[]" in blocks[2]["text"]["text"]
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+def test_route_payload_entity_created():
+    payload = {"eventType": "entityCreated"}
+    blocks = route_payload_to_template(payload)
+    assert len(blocks) == 5 # Should use template_entity_created
+
+def test_route_payload_entity_deleted():
+    payload = {"eventType": "entityDeleted"}
+    blocks = route_payload_to_template(payload)
+    assert len(blocks) == 5 # Should use template_entity_deleted
+
+def test_route_payload_test_case_result():
+    payload = {"eventType": "testCaseResult"}
+    blocks = route_payload_to_template(payload)
+    assert len(blocks) == 5 # Should use template_dq_failure
+
+def test_route_payload_ownership_change():
+    payload = {
+        "eventType": "entityUpdated",
+        "changeDescription": {
+            "fieldsUpdated": [{"name": "owner"}]
+        }
+    }
+    blocks = route_payload_to_template(payload)
+    assert "Changed from" in str(blocks)
+
+def test_route_payload_schema_change():
+    payload = {
+        "eventType": "entityUpdated",
+        "changeDescription": {
+            "fieldsAdded": [{"name": "columns"}]
+        }
+    }
+    blocks = route_payload_to_template(payload)
+    assert "*Added:*" in str(blocks)
+
+def test_route_payload_generic_update():
+    payload = {
+        "eventType": "entityUpdated",
+        "changeDescription": {
+            "fieldsUpdated": [{"name": "description"}]
+        }
+    }
+    blocks = route_payload_to_template(payload)
+    # generic returns 4 blocks: header, section, context, actions
+    assert len(blocks) == 4
+
+def test_route_payload_unknown():
+    payload = {"eventType": "unknownEvent"}
+    blocks = route_payload_to_template(payload)
+    assert len(blocks) == 4


### PR DESCRIPTION
## Summary

Implements distinct Slack Block Kit notification templates for OpenMetadata event types.

**Closes #11**

## Changes

### 1. New Module: `src/pulse/templates.py`
Created 5 specialized templates:
- **`template_schema_change`**: Parses `changeDescription` to show added, removed, and updated columns with their new and old values. Gracefully stringifies JSON if applicable.
- **`template_dq_failure`**: Pulls `testCaseResult` details, showing test status and the exact failure message.
- **`template_entity_created`**: Displays new asset details including owner and tier.
- **`template_ownership_change`**: Extracts `owner` fields from `changeDescription` to show previous and new ownership.
- **`template_entity_deleted`**: Shows which user triggered the deletion (`updatedBy`).
- **`template_generic`**: Fallback layout for other update events.

### 2. Refactored `src/pulse/notifier.py`
- Removed internal block formatting logic and transferred it to `templates.py`.
- Now relies on `route_payload_to_template(payload)` which dynamically inspects the event type and change contents to render the appropriate Block Kit template.

### 3. Tests
- Created `tests/test_templates.py` containing thorough unit tests for all 5 templates.
- Includes tests simulating missing or improperly formatted payload fields to ensure `KeyError` resilience (graceful degradation).
- Updated `tests/test_notifier.py` to strip out removed internals and cleanly focus on the `slack_sdk` `WebClient` dispatch logic.

## Acceptance Criteria ✅
- [x] 5 distinct template functions.
- [x] Each produces valid Slack Block Kit JSON layouts.
- [x] Missing/optional fields are handled gracefully via `.get()` and defensive JSON parsing logic.
- [x] Test coverage via `pytest tests/test_templates.py tests/test_notifier.py -v`.