### PR TITLE
test: upgrade webhook tests to httpx AsyncClient to fulfill #12

### DIFF
--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,14 +1,12 @@
 """Tests for the webhook receiver endpoint."""
 
-from unittest.mock import AsyncMock, patch
-
+import httpx
 import pytest
-from fastapi.testclient import TestClient
+from fastapi import FastAPI
+from unittest.mock import AsyncMock, patch
 
 from pulse.server import app
 from pulse.webhook_receiver import OMChangeEvent
-
-client = TestClient(app)
 
 # ---------------------------------------------------------------------------
 # Valid payload helpers
@@ -48,12 +46,14 @@ _VALID_PAYLOADS = [
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("payload", _VALID_PAYLOADS, ids=[
     p["eventType"] for p in _VALID_PAYLOADS
 ])
-def test_webhook_accepts_all_event_types(payload):
+async def test_webhook_accepts_all_event_types(payload):
     """POST /webhook returns 200 for every supported OM event type."""
-    resp = client.post("/webhook", json=payload)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/webhook", json=payload)
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
 
@@ -63,37 +63,45 @@ def test_webhook_accepts_all_event_types(payload):
 # ---------------------------------------------------------------------------
 
 
-def test_webhook_rejects_missing_event_type():
+@pytest.mark.asyncio
+async def test_webhook_rejects_missing_event_type():
     """Missing required `eventType` returns 400."""
     payload = {"entityType": "table", "entityFullyQualifiedName": "x.y.z"}
-    resp = client.post("/webhook", json=payload)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/webhook", json=payload)
     assert resp.status_code == 400
     assert "detail" in resp.json()
 
 
-def test_webhook_rejects_invalid_event_type():
+@pytest.mark.asyncio
+async def test_webhook_rejects_invalid_event_type():
     """An unsupported eventType value returns 400."""
     payload = {
         "eventType": "entityMutated",
         "entityType": "table",
         "entityFullyQualifiedName": "x.y.z",
     }
-    resp = client.post("/webhook", json=payload)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/webhook", json=payload)
     assert resp.status_code == 400
     assert "detail" in resp.json()
 
 
-def test_webhook_rejects_empty_body():
+@pytest.mark.asyncio
+async def test_webhook_rejects_empty_body():
     """An empty JSON object returns 400."""
-    resp = client.post("/webhook", json={})
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/webhook", json={})
     assert resp.status_code == 400
     assert "detail" in resp.json()
 
 
-def test_webhook_rejects_missing_entity_type():
+@pytest.mark.asyncio
+async def test_webhook_rejects_missing_entity_type():
     """Missing required `entityType` returns 400."""
     payload = {"eventType": "entityCreated"}
-    resp = client.post("/webhook", json=payload)
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/webhook", json=payload)
     assert resp.status_code == 400
     assert "detail" in resp.json()
 
@@ -103,7 +111,8 @@ def test_webhook_rejects_missing_entity_type():
 # ---------------------------------------------------------------------------
 
 
-def test_webhook_passes_event_to_notifier():
+@pytest.mark.asyncio
+async def test_webhook_passes_event_to_notifier():
     """Valid payload is forwarded to notifier.dispatch_event()."""
     mock_dispatch = AsyncMock()
     payload = {
@@ -112,7 +121,8 @@ def test_webhook_passes_event_to_notifier():
         "entityFullyQualifiedName": "sample.public.orders",
     }
     with patch("pulse.webhook_receiver.dispatch_event", mock_dispatch):
-        resp = client.post("/webhook", json=payload)
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post("/webhook", json=payload)
 
     assert resp.status_code == 200
     mock_dispatch.assert_called_once()
@@ -122,7 +132,8 @@ def test_webhook_passes_event_to_notifier():
     assert dispatched["entityFullyQualifiedName"] == "sample.public.orders"
 
 
-def test_webhook_preserves_extra_fields():
+@pytest.mark.asyncio
+async def test_webhook_preserves_extra_fields():
     """Extra fields from OM are preserved and passed to the notifier."""
     mock_dispatch = AsyncMock()
     payload = {
@@ -133,7 +144,8 @@ def test_webhook_preserves_extra_fields():
         "currentVersion": 0.2,
     }
     with patch("pulse.webhook_receiver.dispatch_event", mock_dispatch):
-        resp = client.post("/webhook", json=payload)
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post("/webhook", json=payload)
 
     assert resp.status_code == 200
     dispatched = mock_dispatch.call_args[0][0]
@@ -168,7 +180,9 @@ def test_om_change_event_model_defaults_fqn():
 # ---------------------------------------------------------------------------
 
 
-def test_root_endpoint():
-    resp = client.get("/")
+@pytest.mark.asyncio
+async def test_root_endpoint():
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/")
     assert resp.status_code == 200
     assert resp.json()["service"] == "openmetadata-pulse"


### PR DESCRIPTION
## Summary

This PR closes **#12**.

**Note:** The vast majority of the required 10+ unit tests covering the webhook parser and notification engine (including templates, mock assertions, and missing fields tests) were proactively implemented and merged in earlier PRs (#36, #37, and #39).

This PR adds the final requirement: converting the `TestClient` synchronous tests in `test_webhook.py` to use `httpx.AsyncClient` with `pytest.mark.asyncio`. This fulfills the requirement of testing the endpoints asynchronously using the `ASGITransport` provided by `httpx`.

## Acceptance Criteria Check
- [x] 10+ test functions across `test_webhook.py` and `test_notifier.py` (Currently 30+ tests merged)
- [x] Webhook tests: valid → 200, malformed → 400, all 5 event types
- [x] Notifier tests: each template produces valid Block Kit JSON
- [x] All tests pass
- [x] Use `pytest-asyncio` for async tests (`test_webhook.py` has now been upgraded to asynchronous execution using `httpx.AsyncClient`)