### PR TITLE
feat: Implement Resiliency (Retries and Circuit Breakers)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     "pydantic>=2.6,<3",
     "pydantic-settings>=2.2,<3",
     "httpx>=0.27,<1",
+    "tenacity>=8.2,<10",
+    "pybreaker>=1.2,<2",
 ]
 
 [project.optional-dependencies]

--- a/src/pulse/notifier.py
+++ b/src/pulse/notifier.py
@@ -7,11 +7,33 @@ from typing import Any
 import structlog
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 from pulse.config import settings
+from pulse.resilience import error_envelope, is_retryable_slack_error, slack_breaker
 from pulse.templates import EVENT_EMOJI, _humanize_event_type, route_payload_to_template
 
 logger = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Resilient Helpers
+# ---------------------------------------------------------------------------
+
+@slack_breaker
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=0.5, min=1, max=10),
+    retry=retry_if_exception(is_retryable_slack_error),
+    reraise=True,
+)
+def _post_slack_message(
+    client: WebClient,
+    channel: str,
+    blocks: list[dict[str, Any]],
+    text: str,
+) -> None:
+    client.chat_postMessage(channel=channel, blocks=blocks, text=text)
+
 
 # ---------------------------------------------------------------------------
 # Slack client (lazy — only created when a valid token is configured)
@@ -70,11 +92,7 @@ async def dispatch_event(payload: dict[str, Any]) -> None:
     channel = settings.slack_default_channel
 
     try:
-        client.chat_postMessage(
-            channel=channel,
-            blocks=blocks,
-            text=fallback_text,
-        )
+        _post_slack_message(client, channel, blocks, fallback_text)
         logger.info(
             "slack_message_posted",
             channel=channel,
@@ -82,11 +100,19 @@ async def dispatch_event(payload: dict[str, Any]) -> None:
             fqn=entity_fqn,
         )
     except SlackApiError as exc:
-        logger.error(
-            "slack_post_failed",
+        error_envelope(
+            "slack_dispatch",
+            exc,
             channel=channel,
             event_type=event_type,
             fqn=entity_fqn,
-            error=str(exc),
             response=str(exc.response.data) if exc.response else None,
+        )
+    except Exception as exc:
+        error_envelope(
+            "slack_dispatch",
+            exc,
+            channel=channel,
+            event_type=event_type,
+            fqn=entity_fqn,
         )

--- a/src/pulse/om_client.py
+++ b/src/pulse/om_client.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import httpx
 import structlog
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 from pulse.config import settings
 from pulse.exceptions import (
@@ -25,6 +26,7 @@ from pulse.exceptions import (
     OMConnectionError,
     OMNotFoundError,
 )
+from pulse.resilience import om_breaker
 
 logger = structlog.get_logger(__name__)
 
@@ -34,7 +36,7 @@ logger = structlog.get_logger(__name__)
 _TIMEOUT = httpx.Timeout(connect=5.0, read=15.0, write=10.0, pool=5.0)
 _MAX_RETRIES = 3
 _RETRY_BACKOFF_BASE = 0.5  # seconds
-_RETRYABLE_STATUS_CODES = {502, 503, 504}
+_RETRYABLE_STATUS_CODES = {429, 502, 503, 504}
 
 
 # ---------------------------------------------------------------------------
@@ -67,6 +69,22 @@ def _raise_for_status(response: httpx.Response, url: str) -> None:
     raise OMClientError(detail, status_code=code, url=url)
 
 
+def _is_retryable_om_error(exc: BaseException) -> bool:
+    """Determine if an exception should trigger a retry."""
+    if isinstance(exc, OMConnectionError):
+        return True
+    if isinstance(exc, OMClientError) and exc.status_code in _RETRYABLE_STATUS_CODES:
+        return True
+    return False
+
+
+@om_breaker
+@retry(
+    stop=stop_after_attempt(_MAX_RETRIES),
+    wait=wait_exponential(multiplier=_RETRY_BACKOFF_BASE, min=1, max=10),
+    retry=retry_if_exception(_is_retryable_om_error),
+    reraise=True,
+)
 async def _request_with_retry(
     method: str,
     url: str,
@@ -74,57 +92,27 @@ async def _request_with_retry(
     params: dict[str, Any] | None = None,
     json_body: dict[str, Any] | None = None,
 ) -> httpx.Response:
-    """Execute an HTTP request with exponential-backoff retry on transient errors."""
-    last_exc: Exception | None = None
-
-    for attempt in range(1, _MAX_RETRIES + 1):
-        try:
-            async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-                response = await client.request(
-                    method,
-                    url,
-                    headers=_auth_headers(),
-                    params=params,
-                    json=json_body,
-                )
-
-            if response.status_code not in _RETRYABLE_STATUS_CODES:
-                _raise_for_status(response, url)
-                return response
-
-            last_exc = OMClientError(
-                response.text[:500],
-                status_code=response.status_code,
-                url=url,
-            )
-            logger.warning(
-                "om_request_retryable",
-                attempt=attempt,
-                status=response.status_code,
-                url=url,
+    """Execute an HTTP request with exponential-backoff retry and a circuit breaker."""
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            response = await client.request(
+                method,
+                url,
+                headers=_auth_headers(),
+                params=params,
+                json=json_body,
             )
 
-        except httpx.ConnectError as exc:
-            last_exc = OMConnectionError(
-                f"Cannot connect to OpenMetadata at {url}: {exc}",
-                url=url,
-            )
-            logger.warning("om_connect_error", attempt=attempt, url=url, error=str(exc))
+        _raise_for_status(response, url)
+        return response
 
-        except httpx.TimeoutException as exc:
-            last_exc = OMConnectionError(
-                f"Timeout connecting to OpenMetadata at {url}: {exc}",
-                url=url,
-            )
-            logger.warning("om_timeout", attempt=attempt, url=url, error=str(exc))
+    except httpx.ConnectError as exc:
+        logger.warning("om_connect_error", url=url, error=str(exc))
+        raise OMConnectionError(f"Cannot connect to OpenMetadata at {url}: {exc}", url=url) from exc
 
-        if attempt < _MAX_RETRIES:
-            wait = _RETRY_BACKOFF_BASE * (2 ** (attempt - 1))
-            await asyncio.sleep(wait)
-
-    # All retries exhausted
-    assert last_exc is not None
-    raise last_exc
+    except httpx.TimeoutException as exc:
+        logger.warning("om_timeout", url=url, error=str(exc))
+        raise OMConnectionError(f"Timeout connecting to OpenMetadata at {url}: {exc}", url=url) from exc
 
 
 # ---------------------------------------------------------------------------

--- a/src/pulse/resilience.py
+++ b/src/pulse/resilience.py
@@ -1,0 +1,68 @@
+"""Resilience infrastructure for OpenMetadata Pulse.
+
+Provides globally configured circuit breakers and error formatting utilities
+to ensure the bot does not crash and handles transient failures gracefully.
+"""
+
+from typing import Any
+
+import pybreaker
+import structlog
+from slack_sdk.errors import SlackApiError
+
+logger = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Circuit Breakers
+# ---------------------------------------------------------------------------
+
+# Circuit breaker for OpenMetadata API
+# Trips after 5 failures, attempts a reset after 60 seconds
+om_breaker = pybreaker.CircuitBreaker(
+    fail_max=5,
+    reset_timeout=60,
+    state_storage=pybreaker.CircuitMemoryStorage(),
+    name="openmetadata",
+)
+
+# Circuit breaker for Slack API
+# Trips after 5 failures, attempts a reset after 60 seconds
+slack_breaker = pybreaker.CircuitBreaker(
+    fail_max=5,
+    reset_timeout=60,
+    state_storage=pybreaker.CircuitMemoryStorage(),
+    name="slack",
+)
+
+def is_retryable_slack_error(exc: Exception) -> bool:
+    """Return True if the SlackApiError should trigger a retry."""
+    if not isinstance(exc, SlackApiError):
+        return False
+    # Slack API returns 429 for rate limits, or 5xx for server errors
+    status = exc.response.status_code if exc.response else 500
+    return status == 429 or status >= 500
+
+
+# ---------------------------------------------------------------------------
+# Error Envelope
+# ---------------------------------------------------------------------------
+
+def error_envelope(action: str, exc: Exception, **kwargs: Any) -> dict[str, Any]:
+    """Standardize error logging shape for unhandled exceptions.
+    
+    Args:
+        action: What the system was trying to do (e.g. "webhook_processing").
+        exc: The exception that was caught.
+        **kwargs: Additional context variables to log.
+    
+    Returns:
+        A dictionary representation of the error.
+    """
+    error_payload = {
+        "action": action,
+        "error_type": exc.__class__.__name__,
+        "message": str(exc),
+        "context": kwargs,
+    }
+    logger.error("pulse_error", **error_payload, exc_info=True)
+    return error_payload

--- a/src/pulse/webhook_receiver.py
+++ b/src/pulse/webhook_receiver.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ValidationError
 
 from pulse.notifier import dispatch_event
+from pulse.resilience import error_envelope
 
 logger = structlog.get_logger(__name__)
 
@@ -76,5 +77,18 @@ async def receive_webhook(request: Request) -> dict[str, str]:
         fqn=event.entityFullyQualifiedName,
     )
 
-    await dispatch_event(event.model_dump())
+    try:
+        await dispatch_event(event.model_dump())
+    except Exception as exc:
+        error_envelope(
+            "webhook_processing",
+            exc,
+            event_type=event.eventType,
+            fqn=event.entityFullyQualifiedName,
+        )
+        return JSONResponse(  # type: ignore[return-value]
+            status_code=500,
+            content={"detail": "Internal server error during dispatch"},
+        )
+
     return {"status": "ok"}

--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -1,0 +1,102 @@
+"""Tests for the resilience infrastructure (retries and circuit breakers)."""
+
+import pytest
+import pybreaker
+from unittest.mock import MagicMock
+
+from slack_sdk.errors import SlackApiError
+
+from pulse.resilience import (
+    slack_breaker,
+    om_breaker,
+    is_retryable_slack_error,
+    error_envelope,
+)
+from pulse.om_client import _is_retryable_om_error
+from pulse.exceptions import OMConnectionError, OMClientError
+
+
+def test_is_retryable_slack_error():
+    # 429 Rate Limit
+    response = MagicMock()
+    response.status_code = 429
+    exc_429 = SlackApiError("rate limited", response=response)
+    assert is_retryable_slack_error(exc_429) is True
+
+    # 500 Server Error
+    response.status_code = 500
+    exc_500 = SlackApiError("server error", response=response)
+    assert is_retryable_slack_error(exc_500) is True
+
+    # 400 Bad Request
+    response.status_code = 400
+    exc_400 = SlackApiError("bad request", response=response)
+    assert is_retryable_slack_error(exc_400) is False
+
+    # Non-Slack error
+    assert is_retryable_slack_error(ValueError("oops")) is False
+
+
+def test_is_retryable_om_error():
+    # OMConnectionError is retryable
+    assert _is_retryable_om_error(OMConnectionError("conn error")) is True
+
+    # 502/503/504/429 OMClientError is retryable
+    assert _is_retryable_om_error(OMClientError("502 error", status_code=502)) is True
+    assert _is_retryable_om_error(OMClientError("429 error", status_code=429)) is True
+
+    # 404 OMClientError is not retryable
+    assert _is_retryable_om_error(OMClientError("not found", status_code=404)) is False
+
+    # Other exceptions
+    assert _is_retryable_om_error(ValueError("oops")) is False
+
+
+def test_error_envelope_format():
+    exc = ValueError("test exception")
+    payload = error_envelope("test_action", exc, extra="data")
+    
+    assert payload["action"] == "test_action"
+    assert payload["error_type"] == "ValueError"
+    assert payload["message"] == "test exception"
+    assert payload["context"]["extra"] == "data"
+
+
+@pytest.fixture(autouse=True)
+def reset_breakers():
+    """Reset circuit breakers before each test."""
+    slack_breaker.close()
+    om_breaker.close()
+
+
+def test_slack_circuit_breaker_trips_after_failures():
+    """Verify slack_breaker opens after 5 failures."""
+    
+    @slack_breaker
+    def failing_call():
+        raise ValueError("simulated failure")
+        
+    # Cause 5 failures
+    for _ in range(5):
+        with pytest.raises(ValueError):
+            failing_call()
+            
+    # The 6th call should immediately raise CircuitBreakerError
+    with pytest.raises(pybreaker.CircuitBreakerError):
+        failing_call()
+
+
+@pytest.mark.asyncio
+async def test_om_circuit_breaker_trips():
+    """Verify om_breaker opens after 5 failures."""
+    
+    @om_breaker
+    async def failing_call():
+        raise ValueError("simulated failure")
+        
+    for _ in range(5):
+        with pytest.raises(ValueError):
+            await failing_call()
+            
+    with pytest.raises(pybreaker.CircuitBreakerError):
+        await failing_call()


### PR DESCRIPTION
Fixes #41

Implemented robust error handling and resiliency using `tenacity` for retries and `pybreaker` for circuit breakers.

### Changes:
*   Added `tenacity` and `pybreaker` to `pyproject.toml`.
*   Created `src/pulse/resilience.py` to house global circuit breakers for the OM API and Slack API, and added an `error_envelope` standard log formatter.
*   Refactored `om_client._request_with_retry` to use `tenacity.retry` and decorated it with the OM circuit breaker.
*   Refactored `notifier.dispatch_event` to use a new `_post_slack_message` helper wrapped in a `tenacity.retry` block and decorated with the Slack circuit breaker.
*   Wrapped the core webhook router in a `try/except Exception` block using the new `error_envelope` to catch unexpected unhandled failures.
*   Added unit tests in `tests/test_resilience.py` to verify the circuit breakers correctly trip after consecutive failures.